### PR TITLE
feat: polling fallback for agents without a Monitor-type tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
 .DS_Store
-.claude/settings.local.json
+.claude/
+/plans/
 /tasks/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Polling fallback for agent integrations without a Monitor-type tool: `skills/discuss/poller.sh` blocks on `/api/state`, emits newline-delimited JSON events (`thread.created`, `thread.updated`, `session.done`) plus a `snapshot` baseline line so no concurrent events are dropped between invocations. `skills/discuss/SKILL.md` documents the fallback as Option B, gated on Monitor being unavailable.
+
 ## [0.4.0] - 2026-04-28
 
 ### Added

--- a/skills/discuss/SKILL.md
+++ b/skills/discuss/SKILL.md
@@ -45,7 +45,11 @@ If the user declines the install, stop.
 ToolSearch(query: "select:Monitor,TaskStop", max_results: 2)
 ```
 
-## Step 1: Launch as a persistent Monitor
+## Step 1: Launch discuss and choose an event strategy
+
+Always try Monitor (or an equivalent background-monitoring tool) first. Only if no such tool is available in the current context (e.g. ToolSearch finds nothing and invoking Monitor returns a tool-not-enabled error) fall back to the **polling fallback** described below. Do not use the poller when a monitor-type tool exists — Monitor delivers events push-style with no polling latency. The rest of the steps are the same once you have events flowing.
+
+### Option A — Monitor (preferred)
 
 Run `discuss` directly as the Monitor command — do NOT launch it via Bash with `run_in_background`. Monitor treats each stdout line from its command as an event notification delivered to chat, which is exactly how discuss's newline-delimited JSON events are meant to be consumed.
 
@@ -86,6 +90,54 @@ Notes:
 - Record the `task_id` returned by Monitor — you'll need it for `TaskStop` later.
 - If the port is already bound or the file doesn't exist, discuss exits immediately and Monitor ends without ever emitting a `session.started` event. Read the Monitor output file to surface the error, then stop.
 - In stdin mode, you typically already have the markdown in hand (you generated it). Keep a copy in your scratchpad if you need it later for anchor snippets — there's no file to re-read.
+
+### Option B — Polling fallback (only when no monitor-type tool is available)
+
+Use this only when no Monitor-type background monitoring tool is enabled in the current context. If Monitor (or equivalent) is available, use Option A.
+
+**1. Start discuss in the background:**
+
+```bash
+discuss "$ARGUMENTS" --port <port> > /tmp/discuss-startup.log 2>&1 &
+sleep 2
+curl -s http://127.0.0.1:<port>/api/state | jq -e 'has("threads")' > /dev/null \
+  || { cat /tmp/discuss-startup.log; exit 1; }
+```
+
+Pick a free port by checking which of 7777–7782 isn't already bound (`curl -s http://127.0.0.1:<port>/api/state`). If all are in use, discuss is already running — attach to the existing one.
+
+**2. Enter the event loop — blocking poller:**
+
+This skill's directory (the directory containing this SKILL.md) also contains `poller.sh`. Call it via Bash (blocking, timeout 600000ms). It polls `/api/state` every 5 seconds and exits as soon as something changes:
+
+```bash
+bash <skill-dir>/poller.sh "http://127.0.0.1:<port>"
+```
+
+On the first invocation, pass no baseline — the poller snapshots current state itself. On every subsequent invocation, pass the baseline captured from the previous run's `snapshot` line (see below).
+
+- Exit 0 → one or more new events; parse stdout (one JSON object per line), handle each, then **immediately re-invoke the poller** with the new baseline.
+- Exit 1 → error (API unreachable); report to user and stop.
+- Exit 2 → session ended (discuss exited); summarize threads and stop.
+- Bash tool timeout → not an error; the session is just quiet. Re-invoke the poller with the same baseline.
+
+**3. Handling events from the poller:**
+
+On exit 0, stdout contains one line per changed thread, followed by a final `snapshot` line:
+
+```json
+{"event": "thread.created", "thread": { ...full thread object... }}
+{"event": "thread.updated", "thread": { ...full thread object... }, "prev_count": 1, "current_count": 2}
+{"event": "snapshot", "baseline": {"<thread-id>": 2, "<thread-id>": 0}}
+```
+
+Handle every `thread.created` and `thread.updated` line exactly as you would `thread.created` and `reply.added` Monitor events (see Step 3). On exit 2 the last line is `{"event": "session.done"}` — treat it as the signal to stop and summarize.
+
+**Baseline handling:** always pass the `baseline` object from the `snapshot` line to the next poller invocation — do NOT re-fetch state to rebuild it yourself, or events that arrive in between will be silently dropped. If you post a reply or take while handling an event, bump that thread's count in the baseline first so your own post doesn't re-fire:
+
+```bash
+BASELINE=$(echo "$BASELINE" | jq -c --arg id "$THREAD_ID" '.[$id] += 1')
+```
 
 Optionally `Read` the markdown source afterward for context on anchor snippets (file mode only).
 

--- a/skills/discuss/manifest.txt
+++ b/skills/discuss/manifest.txt
@@ -1,1 +1,2 @@
 SKILL.md
+poller.sh

--- a/skills/discuss/poller.sh
+++ b/skills/discuss/poller.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# poller.sh — blocking discuss event poller (fallback for when no Monitor-type
+# background monitoring tool is available)
+#
+# Usage: poller.sh <url> [baseline_json]
+#
+# Polls the discuss /api/state endpoint every 5 seconds. Blocks until a new
+# thread appears or an existing thread gains a new reply or take. When
+# something changes, prints one JSON object per line for EVERY change detected
+# in that poll, followed by a final snapshot line:
+#
+#   {"event": "thread.created", "thread": {...}}
+#   {"event": "thread.updated", "thread": {...}, "prev_count": 1, "current_count": 2}
+#   {"event": "snapshot", "baseline": {"<thread-id>": <count>, ...}}
+#
+# Pass the "baseline" value from the snapshot line as $2 on the next
+# invocation so no events are dropped between invocations. If you post a reply
+# or take yourself, bump that thread's count in the baseline first:
+#   BASELINE=$(echo "$BASELINE" | jq -c --arg id "$THREAD_ID" '.[$id] += 1')
+#
+# Exit codes:
+#   0  — change detected; event lines + snapshot line printed to stdout
+#   1  — error (API unreachable at startup, or invalid args)
+#   2  — session ended (discuss exited); prints {"event": "session.done"}
+
+set -euo pipefail
+
+URL="${1:-}"
+BASELINE_JSON="${2:-}"
+TMPFILE=$(mktemp /tmp/discuss-state.XXXXXX)
+trap 'rm -f "$TMPFILE"' EXIT
+
+if [ -z "$URL" ]; then
+  echo "Usage: poller.sh <discuss-url> [baseline_json]" >&2
+  exit 1
+fi
+
+# Fetch /api/state into TMPFILE. Returns 0 if we got a 200 with a valid JSON
+# body containing .threads, non-zero otherwise. Never exits the script.
+fetch_state() {
+  local http_code
+  http_code=$(curl -s -o "$TMPFILE" -w "%{http_code}" "$URL/api/state" 2>/dev/null) || return 1
+  [ "$http_code" = "200" ] || return 1
+  jq -e '.threads' "$TMPFILE" > /dev/null 2>&1 || return 1
+  return 0
+}
+
+# Build snapshot from TMPFILE: JSON object mapping thread_id -> (reply_count +
+# take_count). replies and takes are top-level objects keyed by thread ID, not
+# nested in threads.
+snapshot() {
+  jq -c '
+    . as $s |
+    [.threads[].id] |
+    map({
+      key: .,
+      value: (
+        (($s.replies[.] // []) | length) +
+        (($s.takes[.] // []) | length)
+      )
+    }) | from_entries
+  ' "$TMPFILE"
+}
+
+# Establish baseline if not provided
+if [ -z "$BASELINE_JSON" ]; then
+  ATTEMPTS=0
+  until fetch_state; do
+    ATTEMPTS=$((ATTEMPTS + 1))
+    if [ "$ATTEMPTS" -ge 3 ]; then
+      echo "discuss API unreachable at $URL" >&2
+      exit 1
+    fi
+    sleep 2
+  done
+  BASELINE_JSON=$(snapshot)
+fi
+
+FAIL_COUNT=0
+
+while true; do
+  sleep 5
+
+  if ! fetch_state; then
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    if [ "$FAIL_COUNT" -ge 3 ]; then
+      echo '{"event": "session.done"}'
+      exit 2
+    fi
+    continue
+  fi
+  FAIL_COUNT=0
+
+  # Emit every new thread and every thread whose reply+take count grew.
+  EVENTS=$(jq --argjson base "$BASELINE_JSON" -c '
+    . as $s |
+    .threads[] |
+    . as $t |
+    (
+      (($s.replies[$t.id] // []) | length) +
+      (($s.takes[$t.id] // []) | length)
+    ) as $current |
+    if ($base | has($t.id) | not) then
+      {event: "thread.created", thread: $t}
+    elif $current > ($base[$t.id] // 0) then
+      {event: "thread.updated", thread: $t, prev_count: ($base[$t.id] // 0), current_count: $current}
+    else
+      empty
+    end
+  ' "$TMPFILE" 2>/dev/null) || EVENTS=""
+
+  if [ -n "$EVENTS" ]; then
+    echo "$EVENTS"
+    printf '{"event": "snapshot", "baseline": %s}\n' "$(snapshot)"
+    exit 0
+  fi
+done


### PR DESCRIPTION
## Summary

- Adds `skills/discuss/poller.sh`: a blocking poller over `/api/state` for agent contexts where no Monitor-type background monitoring tool is available. Emits newline-delimited JSON events compatible with the Monitor flow:
  - `{"event": "thread.created", "thread": {...}}`
  - `{"event": "thread.updated", "thread": {...}, "prev_count": N, "current_count": M}`
  - a final `{"event": "snapshot", "baseline": {...}}` line so the caller gets a race-free baseline for the next invocation — concurrent events are never silently dropped
  - `{"event": "session.done"}` (exit 2) when discuss goes away
- Survives transient API/jq failures under `set -euo pipefail` (3 consecutive failed polls = session ended)
- Documents the fallback as **Option B** in `skills/discuss/SKILL.md`, explicitly gated on Monitor being unavailable — agents must always prefer Monitor when it exists
- Covers baseline handling, self-post suppression (bump your own thread's count after posting a take), and Bash-tool-timeout-is-not-an-error semantics
- Adds `poller.sh` to `skills/discuss/manifest.txt`
- Ignores local scratch dirs (`.claude/`, `plans/`)

## Test plan

- [x] `shellcheck` clean
- [x] jq snapshot logic dry-run against the real `/api/state` shape (`StateSnapshot`: `threads` array + `replies`/`takes` maps keyed by thread ID)
- [x] Live test against a fake HTTP server: 3 concurrent changes → all 3 event lines + snapshot line emitted (exit 0)
- [x] Server killed mid-run → `session.done` emitted, exit 2
- [x] Transient garbage JSON response → poller retries and recovers instead of dying
- [ ] End-to-end with a real `discuss` session in an agent context without Monitor