### PR TITLE
fix: stdin auto-detect blocks forever in MSYS2/mintty/Git Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Bundled `assets/mermaid.min.js` upgraded from a v8-era build to mermaid v11.14.0 (UMD/iife) so modern flowchart syntax (`subgraph X["label"]`, cylinder shapes, `<br/>` in node labels, unicode arrows) renders correctly. The hydration shim was rewritten to use the v10/v11 promise-based `mermaid.render(id, source)` API with `securityLevel: 'loose'`, surfaces parse failures inline as a `.mermaid-error` note instead of failing silently, and now marks `<pre>` blocks with `mermaid-block`/`no-line-numbers` *before* Prism runs. `highlightCodeBlocks()` skips those blocks (no `line-numbers` class, no `Prism.highlightElement`) so mermaid sources are no longer tokenized by Prism before the SVG render lands. Asset size budget bumped from 700 KB to 4 MB to fit v11.
 
+### Fixed
+- Bare `discuss` no longer hangs at an interactive prompt in MSYS2 / mintty / Git Bash on Windows. Stdin terminal detection now uses the [`is-terminal`](https://crates.io/crates/is-terminal) crate, which recognizes MSYS pseudo-tty named pipes (`\\msys-*-pty*`) as terminals, instead of `std::io::IsTerminal` which reports them as pipes and sent bare `discuss` into the stdin auto-detect arm where it blocked waiting for EOF. POSIX terminals (Linux, macOS, Windows conhost) are unchanged. The same detection now also gates the `discuss update` interactive-confirm path. Closes [#5](https://github.com/codesoda/discuss-cli/issues/5).
+
 ## [0.4.0] - 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,6 +409,7 @@ dependencies = [
  "comrak",
  "directories",
  "flate2",
+ "is-terminal",
  "open",
  "reqwest",
  "self-replace",
@@ -633,6 +634,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -907,6 +914,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,4 @@ tower-http = { version = "0.6", features = ["trace"] }
 tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+is-terminal = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::future::{Future, pending};
-use std::io::{self, IsTerminal, Read};
+use std::io::{self, Read};
 use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 
@@ -55,7 +55,7 @@ where
         command,
     } = args;
 
-    if command.is_none() && file.is_none() && io::stdin().is_terminal() {
+    if command.is_none() && file.is_none() && stdin_is_terminal() {
         eprintln!("{}", cli::Args::command().render_long_help());
         std::process::exit(exit::EXIT_CONFIG_ERROR);
     }
@@ -141,6 +141,16 @@ where
     }
 }
 
+/// Whether stdin is attached to an interactive terminal.
+///
+/// Uses the `is-terminal` crate instead of `std::io::IsTerminal` because on
+/// Windows the std trait reports MSYS2/mintty/Git Bash pseudo-ttys (named
+/// pipes such as `\\msys-*-pty*`) as non-terminals, which made bare `discuss`
+/// block on stdin instead of printing help. See issue #5.
+pub(crate) fn stdin_is_terminal() -> bool {
+    is_terminal::IsTerminal::is_terminal(&io::stdin())
+}
+
 struct MarkdownInput {
     markdown_source: String,
     source_path: Option<PathBuf>,
@@ -159,7 +169,7 @@ fn resolve_input(file: Option<PathBuf>) -> Result<Option<MarkdownInput>> {
                 source_file,
             }))
         }
-        None if !io::stdin().is_terminal() => Ok(Some(read_markdown_stdin()?)),
+        None if !stdin_is_terminal() => Ok(Some(read_markdown_stdin()?)),
         None => Ok(None),
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::env;
 use std::fs;
-use std::io::{self, Cursor, IsTerminal, Write};
+use std::io::{self, Cursor, Write};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -38,7 +38,7 @@ pub fn check() -> Result<String> {
 }
 
 pub fn install(yes: bool) -> Result<String> {
-    let stdin_is_tty = io::stdin().is_terminal();
+    let stdin_is_tty = crate::stdin_is_terminal();
     if !yes && !stdin_is_tty {
         return Err(update_install_error(
             "stdin is not a TTY - rerun with `discuss update -y` to confirm the install non-interactively"


### PR DESCRIPTION
## Summary

Fixes #5 using option (1) from the issue: swap `std::io::IsTerminal` for the [`is-terminal`](https://crates.io/crates/is-terminal) crate for stdin detection.

On Windows, MSYS2/mintty/Git Bash expose stdin as a named-pipe pseudo-tty (`\\msys-*-pty*`). `std::io::IsTerminal::is_terminal()` reports those as pipes (`GetFileType` → `FILE_TYPE_PIPE`), so bare `discuss` at an interactive Git Bash prompt fell into the stdin auto-detect arm and blocked on `read_to_string` waiting for EOF instead of printing help. The `is-terminal` crate parses the pipe name on Windows and correctly identifies MSYS pseudo-ttys as terminals.

## Changes

- Add `is-terminal = "0.4"` dependency (one new transitive dep, `hermit-abi`, non-Windows targets unaffected at runtime).
- Centralize detection in a `pub(crate) fn stdin_is_terminal()` helper in `src/lib.rs`, used by:
  - the bare-`discuss` help-vs-stdin auto-detect (`run` entry + `resolve_input`),
  - the `discuss update` interactive-confirm gate in `src/update.rs`.
- CHANGELOG: `Fixed` entry under Unreleased.

Zero behavior change on POSIX (Linux, macOS) and Windows conhost.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 175 passed, 0 failed (includes `cli_update_requires_yes_when_stdin_is_not_tty`, which exercises the new detection path through the piped-stdin negative case).
- Manual smoke: `printf '# hi' | discuss --no-open` still auto-detects piped stdin and emits `session.started` with `source_file: "<stdin>"`; `discuss --help` renders help.
- The MSYS-positive case can't be exercised on macOS/CI; it relies on `is-terminal`'s documented Windows pipe-name handling.