### PR TITLE
Add cross-platform builds and installers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,14 @@ env:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    name: CI (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,17 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to rebuild, for example v0.6.1"
+        required: true
+        type: string
 
 env:
   RUSTFLAGS: "-D warnings"
   CARGO_INCREMENTAL: "0"
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   build:
@@ -19,10 +26,12 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             runs_on: macos-15
-          # - target: x86_64-apple-darwin
-          #   runs_on: macos-15-intel
-          # - target: x86_64-unknown-linux-gnu
-          #   runs_on: ubuntu-24.04
+          - target: x86_64-apple-darwin
+            runs_on: macos-15-intel
+          - target: x86_64-unknown-linux-gnu
+            runs_on: ubuntu-24.04
+          - target: x86_64-pc-windows-msvc
+            runs_on: windows-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -38,16 +47,27 @@ jobs:
       - name: cargo build --release --target ${{ matrix.target }}
         run: cargo build --release --target "${{ matrix.target }}"
 
-      - name: Package release tarball
+      - name: Package Unix release tarball
+        if: runner.os != 'Windows'
+        shell: bash
         run: |
           mkdir -p dist/package
           install -m 0755 "target/${{ matrix.target }}/release/discuss" dist/package/discuss
-          tar -C dist/package -czf "dist/discuss-${{ github.ref_name }}-${{ matrix.target }}.tar.gz" discuss
+          tar -C dist/package -czf "dist/discuss-${{ env.RELEASE_TAG }}-${{ matrix.target }}.tar.gz" discuss
+
+      - name: Package Windows release archive
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $packageDir = "dist/package"
+          New-Item -ItemType Directory -Force -Path $packageDir | Out-Null
+          Copy-Item "target/${{ matrix.target }}/release/discuss.exe" "$packageDir/discuss.exe"
+          Compress-Archive -Path "$packageDir/discuss.exe" -DestinationPath "dist/discuss-${{ env.RELEASE_TAG }}-${{ matrix.target }}.zip"
 
       - uses: actions/upload-artifact@v4
         with:
           name: release-${{ matrix.target }}
-          path: dist/discuss-${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+          path: dist/discuss-${{ env.RELEASE_TAG }}-${{ matrix.target }}.*
           if-no-files-found: error
 
   publish:
@@ -69,11 +89,11 @@ jobs:
       - name: Generate checksums
         run: |
           cd dist
-          sha256sum discuss-*.tar.gz > checksums-sha256.txt
+          sha256sum discuss-* > checksums-sha256.txt
 
       - name: Extract release notes from CHANGELOG.md
         env:
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ env.RELEASE_TAG }}
         run: |
           VERSION="${TAG#v}"
           PREFIX_TAG="## [${TAG}]"
@@ -99,8 +119,11 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          overwrite_files: true
           body_path: dist/release-notes.md
           files: |
             dist/discuss-*.tar.gz
+            dist/discuss-*.zip
             dist/checksums-sha256.txt
           fail_on_unmatched_files: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +377,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +446,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "zip",
 ]
 
 [[package]]
@@ -2731,6 +2752,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
+zip = { version = "4.6", default-features = false, features = ["deflate-flate2"] }
 thiserror = "2.0.18"
 tokio = { version = "1", features = ["full"] }
 toml = "0.8.23"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,15 @@ Markdown is how engineers share everything that isn't code — PRDs, design docs
 curl -sSL https://raw.githubusercontent.com/codesoda/discuss-cli/main/install.sh | sh
 ```
 
-Downloads the latest release tarball from GitHub, installs the binary to `~/.discuss/bin/`, symlinks `~/.local/bin/discuss`, fetches the `/discuss` skill files into `~/.discuss/skills/discuss/`, and links them into every agent root present (`~/.claude/skills/`, `~/.codex/skills/`, `~/.agents/skills/`).
+Downloads the latest platform release from GitHub, installs the binary to `~/.discuss/bin/`, symlinks `~/.local/bin/discuss`, fetches the `/discuss` skill files into `~/.discuss/skills/discuss/`, and links them into every agent root present (`~/.claude/skills/`, `~/.codex/skills/`, `~/.agents/skills/`). Supported Unix targets are macOS arm64, macOS x86_64, and Linux x86_64.
+
+### Windows PowerShell
+
+```powershell
+irm https://raw.githubusercontent.com/codesoda/discuss-cli/main/install.ps1 | iex
+```
+
+Downloads and verifies the latest Windows x86_64 release, installs `discuss.exe` under `$HOME\.discuss\bin`, adds a command wrapper under `$HOME\.local\bin`, and updates the user PATH. Open a new terminal after installation.
 
 ### From a clone
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,198 @@
+$ErrorActionPreference = "Stop"
+
+$BinaryName = "discuss"
+$RepoUrl = "https://github.com/codesoda/discuss-cli"
+$ApiRepoUrl = "https://api.github.com/repos/codesoda/discuss-cli"
+$RawRepoUrl = "https://raw.githubusercontent.com/codesoda/discuss-cli"
+$InstallDir = Join-Path $HOME ".discuss\bin"
+$LinkDir = Join-Path $HOME ".local\bin"
+$SkillInstallDir = Join-Path $HOME ".discuss\skills\discuss"
+$InstalledBinary = Join-Path $InstallDir "$BinaryName.exe"
+$ScriptDir = if ([string]::IsNullOrWhiteSpace($PSScriptRoot)) { $null } else { $PSScriptRoot }
+
+function Fail([string] $Message) {
+    Write-Error "error: $Message"
+    exit 1
+}
+
+function Status([string] $Message) {
+    Write-Host $Message
+}
+
+function Require-Command([string] $Name) {
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Fail "required command '$Name' was not found"
+    }
+}
+
+function Get-Target {
+    $Architecture = $env:PROCESSOR_ARCHITEW6432
+    if ([string]::IsNullOrWhiteSpace($Architecture)) {
+        $Architecture = $env:PROCESSOR_ARCHITECTURE
+    }
+
+    if ($Architecture -ieq "AMD64") {
+        return "x86_64-pc-windows-msvc"
+    }
+
+    Fail "unsupported Windows architecture '$Architecture'; the available Windows release is x86_64-pc-windows-msvc"
+}
+
+function Get-LatestReleaseTag {
+    $Release = Invoke-RestMethod -Uri "$ApiRepoUrl/releases/latest" -Headers @{ "User-Agent" = "$BinaryName-installer" }
+    $Tag = [string]$Release.tag_name
+    if ($Tag -notmatch '^v[0-9]') {
+        Fail "could not determine the latest release tag"
+    }
+    return $Tag
+}
+
+function Install-Binary([string] $Source) {
+    New-Item -ItemType Directory -Force -Path $InstallDir, $LinkDir | Out-Null
+    Copy-Item -Force $Source $InstalledBinary
+
+    $Wrapper = Join-Path $LinkDir "$BinaryName.cmd"
+    "@echo off`r`n`"$InstalledBinary`" %*`r`n" | Set-Content -Path $Wrapper -Encoding ascii
+
+    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $PathEntries = @($UserPath -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if (-not ($PathEntries | Where-Object { $_.TrimEnd('\') -ieq $LinkDir.TrimEnd('\') })) {
+        $NewPath = if ([string]::IsNullOrWhiteSpace($UserPath)) { $LinkDir } else { "$UserPath;$LinkDir" }
+        [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
+        Status "Added $LinkDir to the user PATH. Open a new terminal before running $BinaryName."
+    }
+}
+
+function Install-Skill([string] $Source) {
+    if (-not (Test-Path $Source -PathType Container)) {
+        Write-Warning "skill source not found at $Source; skipping skill install"
+        return
+    }
+
+    New-Item -ItemType Directory -Force -Path (Split-Path $SkillInstallDir) | Out-Null
+    if (Test-Path $SkillInstallDir) {
+        Remove-Item -Recurse -Force $SkillInstallDir
+    }
+    Copy-Item -Recurse $Source $SkillInstallDir
+
+    foreach ($AgentRoot in @((Join-Path $HOME ".claude"), (Join-Path $HOME ".codex"), (Join-Path $HOME ".agents"))) {
+        if (-not (Test-Path $AgentRoot -PathType Container)) {
+            continue
+        }
+
+        $SkillsDir = Join-Path $AgentRoot "skills"
+        $Target = Join-Path $SkillsDir $BinaryName
+        New-Item -ItemType Directory -Force -Path $SkillsDir | Out-Null
+        if (Test-Path $Target) {
+            $Existing = Get-Item -Force $Target
+            if ($Existing.LinkType) {
+                Remove-Item -Force $Target
+            } else {
+                Write-Warning "$Target exists and is not a link; skipping"
+                continue
+            }
+        }
+
+        New-Item -ItemType Junction -Path $Target -Target $SkillInstallDir | Out-Null
+        Status "Linked skill $Target -> $SkillInstallDir"
+    }
+}
+
+function Install-FromSource {
+    Require-Command "cargo"
+    Status "Building $BinaryName with warnings denied..."
+    Push-Location $ScriptDir
+    try {
+        $env:RUSTFLAGS = "-D warnings"
+        & cargo build --release
+        if ($LASTEXITCODE -ne 0) {
+            Fail "cargo build failed"
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $Source = Join-Path $ScriptDir "target\release\$BinaryName.exe"
+    if (-not (Test-Path $Source -PathType Leaf)) {
+        Fail "expected built binary at $Source"
+    }
+    Install-Binary $Source
+    Install-Skill (Join-Path $ScriptDir "skills\discuss")
+}
+
+function Install-FromDownload {
+    $Target = Get-Target
+    $Tag = Get-LatestReleaseTag
+    $AssetName = "$BinaryName-$Tag-$Target.zip"
+    $TempDir = Join-Path ([IO.Path]::GetTempPath()) ("discuss-install-" + [guid]::NewGuid().ToString("N"))
+    $Archive = Join-Path $TempDir $AssetName
+    $Checksums = Join-Path $TempDir "checksums-sha256.txt"
+
+    New-Item -ItemType Directory -Force -Path $TempDir | Out-Null
+    try {
+        $AssetUrl = "$RepoUrl/releases/download/$Tag/$AssetName"
+        $ChecksumsUrl = "$RepoUrl/releases/download/$Tag/checksums-sha256.txt"
+        Status "Downloading $AssetName..."
+        Invoke-WebRequest -Uri $AssetUrl -OutFile $Archive
+        Invoke-WebRequest -Uri $ChecksumsUrl -OutFile $Checksums
+
+        $Expected = $null
+        foreach ($Line in Get-Content $Checksums) {
+            if ($Line -match "^(?<Hash>[0-9a-fA-F]{64})\s+\*?(?<Name>\S+)$" -and $Matches.Name -eq $AssetName) {
+                $Expected = $Matches.Hash
+                break
+            }
+        }
+        if (-not $Expected) {
+            Fail "checksums-sha256.txt did not contain an entry for $AssetName"
+        }
+        $Actual = (Get-FileHash -Path $Archive -Algorithm SHA256).Hash
+        if ($Actual -ine $Expected) {
+            Fail "sha256 mismatch for $AssetName; refusing to install"
+        }
+
+        $ExtractDir = Join-Path $TempDir "extracted"
+        Expand-Archive -Path $Archive -DestinationPath $ExtractDir -Force
+        $Source = Get-ChildItem -Path $ExtractDir -Filter "$BinaryName.exe" -Recurse -File | Select-Object -First 1
+        if (-not $Source) {
+            Fail "$AssetName did not contain $BinaryName.exe"
+        }
+
+        Install-Binary $Source.FullName
+        $RawBase = "$RawRepoUrl/$Tag/skills/discuss"
+        $Manifest = Join-Path $TempDir "manifest.txt"
+        Invoke-WebRequest -Uri "$RawBase/manifest.txt" -OutFile $Manifest
+        $SkillSource = Join-Path $TempDir "skill"
+        New-Item -ItemType Directory -Force -Path $SkillSource | Out-Null
+        foreach ($FilePath in Get-Content $Manifest) {
+            $RelativePath = $FilePath.Trim()
+            if ([string]::IsNullOrWhiteSpace($RelativePath) -or $RelativePath.StartsWith('#')) {
+                continue
+            }
+            $Destination = Join-Path $SkillSource $RelativePath
+            New-Item -ItemType Directory -Force -Path (Split-Path $Destination) | Out-Null
+            Invoke-WebRequest -Uri "$RawBase/$RelativePath" -OutFile $Destination
+        }
+        Install-Skill $SkillSource
+    } finally {
+        if (Test-Path $TempDir) {
+            Remove-Item -Recurse -Force $TempDir
+        }
+    }
+}
+
+if ($ScriptDir -and (Test-Path (Join-Path $ScriptDir "Cargo.toml"))) {
+    Install-FromSource
+} else {
+    Install-FromDownload
+}
+
+if (-not (Test-Path $InstalledBinary -PathType Leaf)) {
+    Fail "installed binary was not found at $InstalledBinary"
+}
+& $InstalledBinary --version
+if ($LASTEXITCODE -ne 0) {
+    Fail "installed binary failed to run"
+}
+Status "Installed $BinaryName to $InstalledBinary"
+Status "Open a new terminal before using $BinaryName from PATH."

--- a/install.sh
+++ b/install.sh
@@ -71,7 +71,7 @@ detect_target() {
       printf 'x86_64-unknown-linux-gnu'
       ;;
     *)
-      die "unsupported platform ${OS}/${ARCH}; supported targets are aarch64-apple-darwin, x86_64-apple-darwin, and x86_64-unknown-linux-gnu"
+      die "unsupported platform ${OS}/${ARCH}; supported Unix targets are aarch64-apple-darwin, x86_64-apple-darwin, and x86_64-unknown-linux-gnu. Windows users should run install.ps1 with PowerShell."
       ;;
   esac
 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -143,7 +143,7 @@ mod tests {
         let path = tempdir
             .path()
             .join("review")
-            .join("2026-04-23T02:30:00Z.json");
+            .join(format!("{}.json", archive_timestamp(timestamp())));
         let payload = json!({ "threads": [{ "id": "u-1" }] });
 
         write_history_archive(&path, &payload).expect("write archive");

--- a/src/history.rs
+++ b/src/history.rs
@@ -18,7 +18,7 @@ pub fn history_archive_path(
     files_count: usize,
     completed_at: DateTime<Utc>,
 ) -> PathBuf {
-    let timestamp = completed_at.to_rfc3339_opts(SecondsFormat::Secs, true);
+    let timestamp = archive_timestamp(completed_at);
 
     history_dir
         .join(source_name_for_history(source_path, files_count))
@@ -32,6 +32,20 @@ pub fn write_history_archive(path: &Path, transcript_json: &Value) -> io::Result
 
     let bytes = serde_json::to_vec(transcript_json).map_err(io::Error::other)?;
     fs::write(path, bytes)
+}
+
+fn archive_timestamp(completed_at: DateTime<Utc>) -> String {
+    let timestamp = completed_at.to_rfc3339_opts(SecondsFormat::Secs, true);
+
+    #[cfg(windows)]
+    {
+        timestamp.replace(':', "-")
+    }
+
+    #[cfg(not(windows))]
+    {
+        timestamp
+    }
 }
 
 fn source_name_for_history(source_path: Option<&Path>, files_count: usize) -> String {
@@ -90,7 +104,7 @@ mod tests {
             path,
             PathBuf::from("/tmp/history")
                 .join("review_plan")
-                .join("2026-04-23T02:30:00Z.json")
+                .join(format!("{}.json", archive_timestamp(timestamp())))
         );
     }
 
@@ -102,7 +116,7 @@ mod tests {
             path,
             PathBuf::from("/tmp/history")
                 .join("unnamed")
-                .join("2026-04-23T02:30:00Z.json")
+                .join(format!("{}.json", archive_timestamp(timestamp())))
         );
     }
 
@@ -119,7 +133,7 @@ mod tests {
             path,
             PathBuf::from("/tmp/history")
                 .join("multi-3-files")
-                .join("2026-04-23T02:30:00Z.json")
+                .join(format!("{}.json", archive_timestamp(timestamp())))
         );
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -40,8 +40,10 @@ fn init_tracing_in_dir(config: &Config, log_dir: &Path) -> Result<()> {
 }
 
 fn default_log_dir() -> Result<PathBuf> {
-    BaseDirs::new()
-        .map(|base_dirs| base_dirs.home_dir().join(".discuss").join("logs"))
+    env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| BaseDirs::new().map(|base_dirs| base_dirs.home_dir().to_path_buf()))
+        .map(|home_dir| home_dir.join(".discuss").join("logs"))
         .ok_or_else(|| {
             logging_init_error(
                 Path::new("~/.discuss/logs"),

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -73,61 +73,9 @@ fn logging_init_error(path: &Path, source: impl Into<BoxedError>) -> DiscussErro
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::OsString;
-    use std::sync::{Mutex, OnceLock};
-
     use tempfile::tempdir;
 
     use super::*;
-
-    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
-
-    fn env_mutex() -> &'static Mutex<()> {
-        ENV_MUTEX.get_or_init(|| Mutex::new(()))
-    }
-
-    struct EnvGuard {
-        home: Option<OsString>,
-        discuss_log: Option<OsString>,
-    }
-
-    impl EnvGuard {
-        fn set_temp_home(home: &Path) -> Self {
-            let guard = Self {
-                home: env::var_os("HOME"),
-                discuss_log: env::var_os("DISCUSS_LOG"),
-            };
-
-            // SAFETY: callers acquire `env_mutex()` before constructing an EnvGuard,
-            // serializing all process-wide env mutations within these tests.
-            unsafe {
-                env::set_var("HOME", home);
-                env::remove_var("DISCUSS_LOG");
-            }
-
-            guard
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            // SAFETY: same `env_mutex()` invariant as `set_temp_home`; the guard's
-            // lifetime is bounded by the lock the test holds.
-            unsafe {
-                if let Some(home) = &self.home {
-                    env::set_var("HOME", home);
-                } else {
-                    env::remove_var("HOME");
-                }
-
-                if let Some(discuss_log) = &self.discuss_log {
-                    env::set_var("DISCUSS_LOG", discuss_log);
-                } else {
-                    env::remove_var("DISCUSS_LOG");
-                }
-            }
-        }
-    }
 
     #[test]
     fn log_filter_prefers_env_then_config_then_info() {
@@ -143,14 +91,12 @@ mod tests {
 
     #[test]
     fn init_tracing_creates_daily_log_file_for_temp_home() {
-        let _env_guard = env_mutex().lock().expect("env mutex should lock");
         let temp_home = tempdir().expect("temp home should be created");
-        let _env_vars = EnvGuard::set_temp_home(temp_home.path());
+        let log_dir = temp_home.path().join(".discuss").join("logs");
 
-        init_tracing(&Config::default()).expect("tracing should initialize");
+        init_tracing_in_dir(&Config::default(), &log_dir).expect("tracing should initialize");
         tracing::info!("test log event");
 
-        let log_dir = temp_home.path().join(".discuss").join("logs");
         let log_files = fs::read_dir(&log_dir)
             .expect("log dir should exist")
             .map(|entry| entry.expect("log entry should be readable").path())

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::env;
+#[cfg(unix)]
 use std::fs;
 use std::io::{self, Cursor, Write};
 #[cfg(unix)]

--- a/src/update.rs
+++ b/src/update.rs
@@ -15,6 +15,7 @@ use semver::Version;
 use sha2::{Digest, Sha256};
 use tar::Archive;
 use tempfile::{NamedTempFile, TempPath};
+use zip::ZipArchive;
 
 use crate::{DiscussError, Result};
 
@@ -76,7 +77,7 @@ pub fn install(yes: bool) -> Result<String> {
     let replacement = extract_binary(&archive_bytes, &asset_name)?;
     self_replace::self_replace(&replacement).map_err(|source| {
         update_install_error(format!(
-            "could not replace the running binary with {asset_name}: {source} - rerun `discuss update -y` or reinstall with `./install.sh`"
+            "could not replace the running binary with {asset_name}: {source} - rerun `discuss update -y` or reinstall with `install.sh` (Unix) or `install.ps1` (Windows)"
         ))
     })?;
 
@@ -198,14 +199,20 @@ fn target_triple_for(os: &str, arch: &str) -> Result<&'static str> {
         ("macos", "aarch64") => Ok("aarch64-apple-darwin"),
         ("macos", "x86_64") => Ok("x86_64-apple-darwin"),
         ("linux", "x86_64") => Ok("x86_64-unknown-linux-gnu"),
+        ("windows", "x86_64") => Ok("x86_64-pc-windows-msvc"),
         _ => Err(update_install_error(format!(
-            "unsupported platform {os}/{arch} - supported targets are aarch64-apple-darwin, x86_64-apple-darwin, and x86_64-unknown-linux-gnu"
+            "unsupported platform {os}/{arch} - supported targets are aarch64-apple-darwin, x86_64-apple-darwin, x86_64-unknown-linux-gnu, and x86_64-pc-windows-msvc"
         ))),
     }
 }
 
 fn release_asset_name(tag: &str, target: &str) -> String {
-    format!("{BINARY_NAME}-{tag}-{target}.tar.gz")
+    let extension = if target == "x86_64-pc-windows-msvc" {
+        "zip"
+    } else {
+        "tar.gz"
+    };
+    format!("{BINARY_NAME}-{tag}-{target}.{extension}")
 }
 
 fn release_asset_url(tag: &str, asset_name: &str) -> String {
@@ -351,6 +358,14 @@ fn checksum_for_asset(checksums: &str, asset_name: &str) -> Result<String> {
 }
 
 fn extract_binary(archive_bytes: &[u8], asset_name: &str) -> Result<TempPath> {
+    if asset_name.ends_with(".zip") {
+        return extract_zip_binary(archive_bytes, asset_name);
+    }
+
+    extract_tar_binary(archive_bytes, asset_name)
+}
+
+fn extract_tar_binary(archive_bytes: &[u8], asset_name: &str) -> Result<TempPath> {
     let decoder = GzDecoder::new(Cursor::new(archive_bytes));
     let mut archive = Archive::new(decoder);
     let entries = archive.entries().map_err(|source| {
@@ -378,6 +393,34 @@ fn extract_binary(archive_bytes: &[u8], asset_name: &str) -> Result<TempPath> {
         return Ok(replacement);
     }
 
+    archive_missing_binary_error(asset_name)
+}
+
+fn extract_zip_binary(archive_bytes: &[u8], asset_name: &str) -> Result<TempPath> {
+    let mut archive = ZipArchive::new(Cursor::new(archive_bytes)).map_err(|source| {
+        update_install_error(format!(
+            "could not read {asset_name}: {source} - the published zip archive may be corrupt"
+        ))
+    })?;
+
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|source| {
+            update_install_error(format!(
+                "could not read {asset_name}: {source} - the published zip archive may be corrupt"
+            ))
+        })?;
+        if !binary_entry_matches(Path::new(entry.name())) {
+            continue;
+        }
+
+        let replacement = write_replacement_binary(&mut entry, asset_name)?;
+        return Ok(replacement);
+    }
+
+    archive_missing_binary_error(asset_name)
+}
+
+fn archive_missing_binary_error(asset_name: &str) -> Result<TempPath> {
     Err(update_install_error(format!(
         "archive {asset_name} did not contain a {BINARY_NAME} binary - rerun `discuss update --check` to confirm the published assets"
     )))
@@ -386,7 +429,7 @@ fn extract_binary(archive_bytes: &[u8], asset_name: &str) -> Result<TempPath> {
 fn binary_entry_matches(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name == BINARY_NAME)
+        .is_some_and(|name| name == BINARY_NAME || name == format!("{BINARY_NAME}.exe"))
 }
 
 fn write_replacement_binary<R>(reader: &mut R, asset_name: &str) -> Result<TempPath>
@@ -520,6 +563,22 @@ mod tests {
             target_triple_for("linux", "x86_64").expect("linux target"),
             "x86_64-unknown-linux-gnu"
         );
+        assert_eq!(
+            target_triple_for("windows", "x86_64").expect("windows target"),
+            "x86_64-pc-windows-msvc"
+        );
+    }
+
+    #[test]
+    fn release_asset_names_use_zip_for_windows() {
+        assert_eq!(
+            release_asset_name("v1.2.3", "x86_64-pc-windows-msvc"),
+            "discuss-v1.2.3-x86_64-pc-windows-msvc.zip"
+        );
+        assert_eq!(
+            release_asset_name("v1.2.3", "x86_64-unknown-linux-gnu"),
+            "discuss-v1.2.3-x86_64-unknown-linux-gnu.tar.gz"
+        );
     }
 
     #[test]
@@ -530,6 +589,32 @@ mod tests {
             error
                 .to_string()
                 .contains("unsupported platform linux/aarch64")
+        );
+    }
+
+    #[test]
+    fn extracts_windows_binary_from_zip_archive() {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        writer
+            .start_file(
+                "package/discuss.exe",
+                zip::write::SimpleFileOptions::default(),
+            )
+            .expect("zip entry should start");
+        writer
+            .write_all(b"binary-bytes")
+            .expect("zip entry should write");
+        let archive_bytes = writer
+            .finish()
+            .expect("zip archive should finish")
+            .into_inner();
+
+        let replacement =
+            extract_binary(&archive_bytes, "discuss-v1.2.3-x86_64-pc-windows-msvc.zip")
+                .expect("windows binary should extract");
+        assert_eq!(
+            fs::read(replacement).expect("replacement should be readable"),
+            b"binary-bytes"
         );
     }
 


### PR DESCRIPTION
Adds native macOS, Linux, and Windows release artifacts, plus platform-aware installation instructions.

README installation updates:
- Unix installer targets macOS ARM64, macOS x86_64, and Linux x86_64.
- Windows users can use install.ps1 from PowerShell.
- Documents Windows PATH setup and the installed binary location.

The v0.6.1 release assets were rebuilt successfully from this branch.