### PR TITLE
Fix: allow commenting on markdown tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - **Prominent thread navigation** — the "X of Y resolved" control moved out of the muted header meta text into the right-hand tool area next to "Show all", restyled as a real bordered button with a ▾ caret and an accent state while its thread-summary popover is open; the popover now anchors to the right edge of the header. Open thread panels gain ‹ / › buttons that step to the previous/next thread in the same order the summary popover uses (file order → anchor position → creation order), switching files when needed; ‹ disables on the first thread and › on the last. Closes [#40](https://github.com/codesoda/discuss-cli/issues/40).
 
+### Fixed
+
+- **Tables are now commentable in markdown reviews** — each rendered GFM table gets a `.table-wrap` anchor (the same pattern as code blocks' `.pre-wrap`), so clicking a table or selecting cell text opens the comment affordance instead of doing nothing. The server-side block splitter counts each table as one block to match, so `GET /api/files/{fileId}/blocks` and agent-computed anchors stay in lockstep with the browser. Closes [#36](https://github.com/codesoda/discuss-cli/issues/36).
+
 ## [0.8.0] - 2026-08-25
 
 ### Added

--- a/discuss.html
+++ b/discuss.html
@@ -15,7 +15,8 @@
        sibling of the source document for a committed review artefact).
     2. Replace the content inside <section id="doc-content"> with whatever
        document you want reviewed. Keep it to these commentable elements:
-       h1-h5, p, li, blockquote, pre, .quote, .decision, .context, .callout.
+       h1-h5, p, li, blockquote, pre, table, .quote, .decision, .context,
+       .callout.
        (You can nest freely; only the outermost commentable ancestor is
        used as the anchor when a user clicks.)
     3. Optionally pre-seed threads via the JSON block
@@ -670,6 +671,7 @@
     margin: 10px 0;
   }
   #doc-content .pre-wrap pre { margin: 0; }
+  #doc-content .table-wrap { position: relative; }
   #doc-content pre {
     background: var(--pre-bg);
     padding: 10px 12px;
@@ -1627,7 +1629,7 @@
       <!-- ==================== REPLACE THIS BLOCK WITH YOUR CONTENT ==================== -->
       <section id="doc-content">
         <h1>Sample discussion document</h1>
-        <p>This template renders any HTML you place in <code>#doc-content</code> as a commentable document. Every heading, paragraph, list item, blockquote, code block, or stylized box (<code>.quote</code>, <code>.decision</code>, <code>.callout</code>, <code>.context</code>) becomes clickable on load — it gets a stable <code>data-anchor-idx</code> assigned so comments bind to a position that survives page reloads.</p>
+        <p>This template renders any HTML you place in <code>#doc-content</code> as a commentable document. Every heading, paragraph, list item, blockquote, code block, table, or stylized box (<code>.quote</code>, <code>.decision</code>, <code>.callout</code>, <code>.context</code>) becomes clickable on load — it gets a stable <code>data-anchor-idx</code> assigned so comments bind to a position that survives page reloads.</p>
 
         <h2>Markup conventions understood out of the box</h2>
         <ul>
@@ -3046,9 +3048,11 @@
   // Any element matching this selector inside #doc-content becomes commentable.
   // <pre> is commented-on via a generated .pre-wrap wrapper because <pre>'s
   // own overflow-x: auto clips the absolutely-positioned gutter marker.
+  // <table> gets a generated .table-wrap wrapper for the same reason:
+  // position: relative on table elements is unreliable across engines.
   // The server mirrors this segmentation in src/blocks.rs for the
   // GET /api/files/{fileId}/blocks endpoint; keep the two in sync.
-  const COMMENTABLE_SELECTOR = 'h1, h2, h3, h4, h5, p, li, blockquote, .pre-wrap, .quote, .decision, .callout, .context';
+  const COMMENTABLE_SELECTOR = 'h1, h2, h3, h4, h5, p, li, blockquote, .pre-wrap, .table-wrap, .quote, .decision, .callout, .context';
   function assignAnchorIndices() {
     const doc = document.getElementById('doc-content');
     if (!doc || doc.querySelector(':scope > .image-review')) return;
@@ -3060,6 +3064,14 @@
       wrap.className = 'pre-wrap';
       pre.parentElement.insertBefore(wrap, pre);
       wrap.appendChild(pre);
+    });
+    // Wrap tables the same way so each table is one commentable anchor.
+    doc.querySelectorAll('table').forEach(table => {
+      if (table.parentElement && table.parentElement.classList.contains('table-wrap')) return;
+      const wrap = document.createElement('div');
+      wrap.className = 'table-wrap';
+      table.parentElement.insertBefore(wrap, table);
+      wrap.appendChild(table);
     });
     const nodes = Array.from(doc.querySelectorAll(COMMENTABLE_SELECTOR));
     // If an element is nested inside another commentable (e.g. <li> inside a

--- a/skills/discuss/SKILL.md
+++ b/skills/discuss/SKILL.md
@@ -360,7 +360,7 @@ If you regenerate the markdown mid-session (e.g. the user fixed code under revie
 }
 ```
 
-Anchors are 1-based indices of commentable block elements (headings, paragraphs, list items, code blocks) in document order — the same units as `anchorStart` on `thread.created`. On success the server re-renders, bumps `sourceVersion` (visible in `/api/state`), and broadcasts `source.updated` on SSE and stdout; the browser swaps the document in place and keeps every conversation. Orphaned threads stay visible to the user, flagged as orphaned. You may pass `sourceVersion` when creating threads via `POST /api/threads` to get a `409 stale_source_version` instead of anchoring against a document that changed under you.
+Anchors are 1-based indices of commentable block elements (headings, paragraphs, list items, code blocks, tables) in document order — the same units as `anchorStart` on `thread.created`. On success the server re-renders, bumps `sourceVersion` (visible in `/api/state`), and broadcasts `source.updated` on SSE and stdout; the browser swaps the document in place and keeps every conversation. Orphaned threads stay visible to the user, flagged as orphaned. You may pass `sourceVersion` when creating threads via `POST /api/threads` to get a `409 stale_source_version` instead of anchoring against a document that changed under you.
 
 ## Stdout event kinds
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -26,8 +26,9 @@ pub struct Block {
 }
 
 /// Segments markdown into the commentable blocks the browser will index:
-/// headings h1–h5, paragraphs, top-level list items, blockquotes, and code
-/// blocks (including the frontmatter `pre`, which the browser counts first).
+/// headings h1–h5, paragraphs, top-level list items, blockquotes, tables, and
+/// code blocks (including the frontmatter `pre`, which the browser counts
+/// first).
 /// Footnote definitions render as list items at the end of the document, so
 /// they are appended after all other blocks.
 pub fn markdown_blocks(markdown: &str) -> Vec<Block> {
@@ -63,6 +64,14 @@ pub fn markdown_blocks(markdown: &str) -> Vec<Block> {
                     breadcrumb(&heading_stack),
                 ));
             }
+            NodeValue::Table(_) => {
+                // The browser wraps each <table> in a .table-wrap anchor —
+                // one block per table.
+                blocks.push((
+                    truncate_snippet(&plain_text(node)),
+                    breadcrumb(&heading_stack),
+                ));
+            }
             NodeValue::CodeBlock(code_block) => {
                 blocks.push((
                     truncate_snippet(code_block.literal.trim_end()),
@@ -93,7 +102,7 @@ pub fn markdown_blocks(markdown: &str) -> Vec<Block> {
                     breadcrumb(&heading_stack),
                 ));
             }
-            // Tables, thematic breaks, and raw HTML blocks are not commentable.
+            // Thematic breaks and raw HTML blocks are not commentable.
             _ => {}
         }
     }
@@ -217,10 +226,22 @@ mod tests {
     }
 
     #[test]
-    fn tables_and_thematic_breaks_are_skipped() {
+    fn tables_are_single_blocks_and_thematic_breaks_are_skipped() {
         let blocks = snippets("before\n\n| a | b |\n| - | - |\n| c | d |\n\n---\n\nafter\n");
 
-        assert_eq!(blocks, vec!["before", "after"]);
+        assert_eq!(blocks, vec!["before", "a b c d", "after"]);
+    }
+
+    #[test]
+    fn tables_get_heading_breadcrumb_and_document_order_index() {
+        let blocks = markdown_blocks("# Plan\n\nintro\n\n| a |\n| - |\n| b |\n\nafter\n");
+
+        assert_eq!(
+            blocks.iter().map(|b| b.index).collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+        assert_eq!(blocks[2].snippet, "a b");
+        assert_eq!(blocks[2].breadcrumb, "Plan");
     }
 
     #[test]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2952,6 +2952,40 @@ async fn get_api_file_blocks_returns_segmentation_with_source_version() {
 }
 
 #[tokio::test]
+async fn get_api_file_blocks_counts_tables_as_single_blocks() {
+    let addr = free_loopback_addr();
+    let app_state = AppState::for_process()
+        .with_markdown_source("# Plan\n\nintro\n\n| a | b |\n| - | - |\n| c | d |\n\nafter\n");
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let server = tokio::spawn(serve(addr, app_state, async move {
+        let _ = shutdown_rx.await;
+    }));
+
+    wait_for_server(addr).await;
+
+    let response = get_path(addr, "/api/files/f-1/blocks").await;
+    assert!(response.starts_with("HTTP/1.1 200"), "response: {response}");
+    let body = response_json(&response);
+    // The table is one block, matching the browser's .table-wrap anchor.
+    assert_eq!(
+        body["blocks"],
+        json!([
+            { "index": 1, "snippet": "Plan", "breadcrumb": "Plan" },
+            { "index": 2, "snippet": "intro", "breadcrumb": "Plan" },
+            { "index": 3, "snippet": "a b c d", "breadcrumb": "Plan" },
+            { "index": 4, "snippet": "after", "breadcrumb": "Plan" }
+        ])
+    );
+
+    shutdown_tx.send(()).expect("send shutdown signal");
+    timeout(Duration::from_secs(1), server)
+        .await
+        .expect("server exits within timeout")
+        .expect("server task should not panic")
+        .expect("server shutdown should succeed");
+}
+
+#[tokio::test]
 async fn get_api_file_blocks_maps_diff_files_through_synthesized_markdown() {
     use discuss::state::{File, FileId, FileKind, Source};
 


### PR DESCRIPTION
## The bug

In markdown reviews, table content could not receive comments. comrak (with `extension.table = true`) renders GFM table cells as bare inline content — no `<p>` wrapper — and `COMMENTABLE_SELECTOR` in `discuss.html` matched no table elements, so nothing inside a `<table>` ever got a `data-anchor-idx`. Both comment paths then bailed silently:

- **click**: `e.target.closest('#doc-content [data-anchor-idx]')` found no ancestor, so clicking a cell did nothing
- **selection**: `closestAnchor()` in `selectionRange()` returned `null`, so `updateSelectionPopup()` hid the popup instead of showing the "Comment" affordance

Long-standing gap (identical in v0.5.0–v0.7.0), surfaced by a table-heavy plan doc.

## Approach: table-level anchor (option 1 from #36)

`assignAnchorIndices()` now wraps each `<table>` in a `.table-wrap` div — the same pattern as the existing client-generated `.pre-wrap` wrapper for `<pre>` — and `.table-wrap` was added to `COMMENTABLE_SELECTOR`. Each table is one commentable anchor.

Why table-level rather than per-cell (`td, th`): it's the minimum change that solves the problem, matches the established `.pre-wrap` pattern exactly (including `position: relative` for the gutter marker), and avoids the interaction noted in the issue where the outermost-ancestor filter makes table- and cell-level anchors mutually exclusive. Per-cell anchors can be layered on later if coarse granularity proves painful.

## Client/server segmentation parity

Since #39 the server mirrors the browser's block segmentation (`GET /api/files/{fileId}/blocks`, anchor validation on `POST /api/threads`). `src/blocks.rs` previously skipped `NodeValue::Table`; it now emits **one block per table** (snippet from the table's plain text, heading breadcrumb preserved), keeping agent-computed anchors in lockstep with the browser's `.table-wrap` anchors. The skill doc (`skills/discuss/SKILL.md`) anchor description was updated to include tables.

## Tests

- `src/blocks.rs`: updated `tables_are_single_blocks_and_thematic_breaks_are_skipped` (tables now produce a block; thematic breaks still skipped) and added `tables_get_heading_breadcrumb_and_document_order_index`
- `tests/server.rs`: added `get_api_file_blocks_counts_tables_as_single_blocks` integration test asserting the blocks endpoint counts a table as index 3 of 4 with the correct snippet/breadcrumb

## Test evidence

- `cargo test`: **295 passed, 0 failed** (unit + integration incl. template assertions and block-parity tests)
- Inline-JS syntax check: all real inline `<script>` blocks in `discuss.html` pass `node --check`
- E2E (headless browser against `discuss serve` with a table-bearing doc): clicking the table opens the composer anchored to it; saving produces a gutter marker + thread on the `.table-wrap` anchor (#3, matching the server blocks endpoint); code-block (`.pre-wrap`) commenting still works as a regression check

## Screenshots

Clicking the table selects it and opens the composer:

![Table composer open](https://raw.githubusercontent.com/codesoda/discuss-cli/screenshots/issue-36/issue-36/p2-01-table-composer.png)

Saved thread anchored to the table, with gutter marker:

![Table thread marker](https://raw.githubusercontent.com/codesoda/discuss-cli/screenshots/issue-36/issue-36/p2-02-table-thread-marker.png)

Regression check — code blocks (`.pre-wrap`) still commentable:

![Code block composer regression check](https://raw.githubusercontent.com/codesoda/discuss-cli/screenshots/issue-36/issue-36/p2-03-codeblock-composer.png)

Closes #36
