### PR TITLE
Consolidate commentable-block segmentation

### DIFF
--- a/discuss.html
+++ b/discuss.html
@@ -780,8 +780,10 @@
   #doc-content details.front-matter[open] > summary {
     border-bottom: 1px solid var(--line);
   }
-  #doc-content details.front-matter > pre {
+  #doc-content details.front-matter > .pre-wrap {
     margin: 0;
+  }
+  #doc-content details.front-matter > .pre-wrap > pre {
     border-radius: 0 0 4px 4px;
   }
   #doc-content details.collapsible-section {
@@ -2256,7 +2258,6 @@
       if (typeof closeNewThreadEditor === 'function') closeNewThreadEditor();
       doc.innerHTML = payload.renderedHtml;
       wrapCollapsibleSectionsDom();
-      assignAnchorIndices();
       buildHeadingMinimap();
     }
 
@@ -3096,45 +3097,6 @@
     });
   }
 
-  // ---------- Assign stable anchor indices to commentable elements ----------
-  // Any element matching this selector inside #doc-content becomes commentable.
-  // <pre> is commented-on via a generated .pre-wrap wrapper because <pre>'s
-  // own overflow-x: auto clips the absolutely-positioned gutter marker.
-  // <table> gets a generated .table-wrap wrapper for the same reason:
-  // position: relative on table elements is unreliable across engines.
-  // The server mirrors this segmentation in src/blocks.rs for the
-  // GET /api/files/{fileId}/blocks endpoint; keep the two in sync.
-  const COMMENTABLE_SELECTOR = 'h1, h2, h3, h4, h5, p, li, blockquote, .pre-wrap, .table-wrap, .quote, .decision, .callout, .context';
-  function assignAnchorIndices() {
-    const doc = document.getElementById('doc-content');
-    if (!doc || doc.querySelector(':scope > .image-review')) return;
-    // Wrap any <pre> that isn't already wrapped so the marker can live
-    // outside the <pre>'s overflow:auto clipping region.
-    doc.querySelectorAll('pre').forEach(pre => {
-      if (pre.parentElement && pre.parentElement.classList.contains('pre-wrap')) return;
-      const wrap = document.createElement('div');
-      wrap.className = 'pre-wrap';
-      pre.parentElement.insertBefore(wrap, pre);
-      wrap.appendChild(pre);
-    });
-    // Wrap tables the same way so each table is one commentable anchor.
-    doc.querySelectorAll('table').forEach(table => {
-      if (table.parentElement && table.parentElement.classList.contains('table-wrap')) return;
-      const wrap = document.createElement('div');
-      wrap.className = 'table-wrap';
-      table.parentElement.insertBefore(wrap, table);
-      wrap.appendChild(table);
-    });
-    const nodes = Array.from(doc.querySelectorAll(COMMENTABLE_SELECTOR));
-    // If an element is nested inside another commentable (e.g. <li> inside a
-    // <blockquote>), prefer the outermost ancestor so clicks don't ambiguate.
-    const outermost = nodes.filter(n => !nodes.some(other => other !== n && other.contains(n)));
-    outermost.forEach((el, i) => {
-      el.setAttribute('data-anchor-idx', String(i + 1));
-    });
-  }
-  assignAnchorIndices();
-
   // ---------- File sidebar (multi-file sessions) ----------
   // Browser storage here holds a UI preference only (collapsed vs expanded),
   // mirroring the theme pref pattern. Review state never touches storage.
@@ -3435,7 +3397,6 @@
       return;
     }
     wrapCollapsibleSectionsDom();
-    assignAnchorIndices();
     buildHeadingMinimap();
     highlightCodeBlocks();
     if (typeof window.__discussRenderMermaid === 'function') window.__discussRenderMermaid();
@@ -3608,17 +3569,11 @@
   try {
     prepopulated = JSON.parse(document.getElementById('prepopulated-threads').textContent.trim() || '[]');
   } catch { prepopulated = []; }
-  // Resolve anchorSelector → anchorIdx at load time
+  // Resolve anchorSelector only when it selects a server-stamped anchor.
   prepopulated.forEach(t => {
     if (!t.anchorIdx && t.anchorSelector) {
       const el = document.querySelector(`#doc-content ${t.anchorSelector}`);
-      if (el) {
-        // If it didn't already get one, assign it now
-        if (!el.hasAttribute('data-anchor-idx')) {
-          const existingMax = Array.from(document.querySelectorAll('#doc-content [data-anchor-idx]'))
-            .reduce((m, n) => Math.max(m, parseInt(n.getAttribute('data-anchor-idx'))), 0);
-          el.setAttribute('data-anchor-idx', String(existingMax + 1));
-        }
+      if (el && el.hasAttribute('data-anchor-idx')) {
         t.anchorIdx = parseInt(el.getAttribute('data-anchor-idx'));
       }
     }

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -1,17 +1,8 @@
-//! Server-side segmentation of markdown into 1-based commentable blocks.
-//!
-//! This mirrors the browser's anchor-index assignment in `discuss.html`
-//! (`assignAnchorIndices` over `COMMENTABLE_SELECTOR`, filtered to outermost
-//! elements in document order). If that selector changes, this walk must be
-//! updated to match, and vice versa.
+//! Server-side API metadata for 1-based commentable markdown blocks.
 
-use comrak::nodes::{AstNode, NodeValue};
-use comrak::{Arena, parse_document};
 use serde::Serialize;
 
-use crate::render::{render_options, split_frontmatter};
-
-const SNIPPET_MAX_BYTES: usize = 300;
+use crate::render::render_markdown;
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -25,143 +16,17 @@ pub struct Block {
     pub breadcrumb: String,
 }
 
-/// Segments markdown into the commentable blocks the browser will index:
-/// headings h1–h5, paragraphs, top-level list items, blockquotes, tables, and
-/// code blocks (including the frontmatter `pre`, which the browser counts
-/// first).
-/// Footnote definitions render as list items at the end of the document, so
-/// they are appended after all other blocks.
+/// Returns metadata from the same AST plan that stamps the rendered markdown.
 pub fn markdown_blocks(markdown: &str) -> Vec<Block> {
-    let mut blocks = Vec::new();
-    let mut footnotes = Vec::new();
-    let mut heading_stack: Vec<(u8, String)> = Vec::new();
-
-    let body = if let Some((frontmatter, body)) = split_frontmatter(markdown) {
-        blocks.push((truncate_snippet(frontmatter.trim()), String::new()));
-        body
-    } else {
-        markdown
-    };
-
-    let arena = Arena::new();
-    let root = parse_document(&arena, body, &render_options());
-
-    for node in root.children() {
-        match &node.data.borrow().value {
-            NodeValue::Heading(heading) => {
-                // h6 is not in the browser's COMMENTABLE_SELECTOR.
-                if heading.level > 5 {
-                    continue;
-                }
-                let text = plain_text(node);
-                heading_stack.retain(|(level, _)| *level < heading.level);
-                heading_stack.push((heading.level, text.clone()));
-                blocks.push((truncate_snippet(&text), breadcrumb(&heading_stack)));
-            }
-            NodeValue::Paragraph | NodeValue::BlockQuote => {
-                blocks.push((
-                    truncate_snippet(&plain_text(node)),
-                    breadcrumb(&heading_stack),
-                ));
-            }
-            NodeValue::Table(_) => {
-                // The browser wraps each <table> in a .table-wrap anchor —
-                // one block per table.
-                blocks.push((
-                    truncate_snippet(&plain_text(node)),
-                    breadcrumb(&heading_stack),
-                ));
-            }
-            NodeValue::CodeBlock(code_block) => {
-                blocks.push((
-                    truncate_snippet(code_block.literal.trim_end()),
-                    breadcrumb(&heading_stack),
-                ));
-            }
-            NodeValue::List(_) => {
-                // The ul/ol itself is not commentable; each top-level item is
-                // the outermost commentable element (nested lists stay inside
-                // their parent item's block).
-                for item in node.children() {
-                    if matches!(
-                        item.data.borrow().value,
-                        NodeValue::Item(_) | NodeValue::TaskItem(_)
-                    ) {
-                        blocks.push((
-                            truncate_snippet(&plain_text(item)),
-                            breadcrumb(&heading_stack),
-                        ));
-                    }
-                }
-            }
-            NodeValue::FootnoteDefinition(_) => {
-                // Rendered as trailing <li>s inside <section class="footnotes">,
-                // which the browser indexes after everything else.
-                footnotes.push((
-                    truncate_snippet(&plain_text(node)),
-                    breadcrumb(&heading_stack),
-                ));
-            }
-            // Thematic breaks and raw HTML blocks are not commentable.
-            _ => {}
-        }
-    }
-
-    blocks.extend(footnotes);
-    blocks
+    render_markdown(markdown)
+        .blocks
         .into_iter()
-        .enumerate()
-        .map(|(index, (snippet, breadcrumb))| Block {
-            index: index + 1,
-            snippet,
-            breadcrumb,
+        .map(|block| Block {
+            index: block.index,
+            snippet: block.snippet,
+            breadcrumb: block.breadcrumb,
         })
         .collect()
-}
-
-fn breadcrumb(heading_stack: &[(u8, String)]) -> String {
-    heading_stack
-        .iter()
-        .map(|(_, text)| text.as_str())
-        .collect::<Vec<_>>()
-        .join(" › ")
-}
-
-fn plain_text<'a>(node: &'a AstNode<'a>) -> String {
-    let mut out = String::new();
-    collect_plain_text(node, &mut out);
-    out.trim().to_string()
-}
-
-fn collect_plain_text<'a>(node: &'a AstNode<'a>, out: &mut String) {
-    match &node.data.borrow().value {
-        NodeValue::Text(text) => out.push_str(text),
-        NodeValue::Code(code) => out.push_str(&code.literal),
-        NodeValue::SoftBreak | NodeValue::LineBreak => out.push(' '),
-        _ => {
-            for child in node.children() {
-                // Separate nested blocks (paragraphs, nested list items) with
-                // a space so they don't run together in the snippet.
-                if child.data.borrow().value.block() && !out.is_empty() && !out.ends_with(' ') {
-                    out.push(' ');
-                }
-                collect_plain_text(child, out);
-            }
-        }
-    }
-}
-
-fn truncate_snippet(text: &str) -> String {
-    let mut snippet = text.to_string();
-    if snippet.len() <= SNIPPET_MAX_BYTES {
-        return snippet;
-    }
-    let mut boundary = SNIPPET_MAX_BYTES;
-    while !snippet.is_char_boundary(boundary) {
-        boundary -= 1;
-    }
-    snippet.truncate(boundary);
-    snippet
 }
 
 #[cfg(test)]
@@ -291,7 +156,7 @@ mod tests {
         let blocks = markdown_blocks(&long);
 
         assert_eq!(blocks.len(), 1);
-        assert!(blocks[0].snippet.len() <= SNIPPET_MAX_BYTES);
+        assert!(blocks[0].snippet.len() <= 300);
         assert!(blocks[0].snippet.chars().all(|c| c == 'é'));
     }
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,16 +1,21 @@
-use comrak::{Options, markdown_to_html};
+//! Pure markdown rendering and its shared commentable-block plan.
+
+use std::collections::HashMap;
+use std::fmt::{self, Write};
+
+use comrak::html::{ChildRendering, Context, format_document_with_formatter, format_node_default};
+use comrak::nodes::{AstNode, NodeValue};
+use comrak::options::Plugins;
+use comrak::{Arena, Options, parse_document};
+
+const SNIPPET_MAX_BYTES: usize = 300;
+const ANCHOR_MARKER_PREFIX: &str = "<!--discuss-anchor-";
 
 pub fn render(markdown: &str) -> String {
-    if let Some((frontmatter, body)) = split_frontmatter(markdown) {
-        let mut out = render_frontmatter_block(frontmatter);
-        out.push_str(&markdown_to_html(body, &render_options()));
-        out
-    } else {
-        markdown_to_html(markdown, &render_options())
-    }
+    render_markdown(markdown).html
 }
 
-pub(crate) fn render_options() -> Options<'static> {
+fn render_options() -> Options<'static> {
     let mut options = Options::default();
     options.extension.table = true;
     options.extension.strikethrough = true;
@@ -20,7 +25,7 @@ pub(crate) fn render_options() -> Options<'static> {
     options
 }
 
-pub(crate) fn split_frontmatter(input: &str) -> Option<(&str, &str)> {
+fn split_frontmatter(input: &str) -> Option<(&str, &str)> {
     let first_newline = input.find('\n')?;
     if input[..first_newline].trim_end() != "---" {
         return None;
@@ -39,9 +44,281 @@ pub(crate) fn split_frontmatter(input: &str) -> Option<(&str, &str)> {
     None
 }
 
-fn render_frontmatter_block(yaml: &str) -> String {
+pub(crate) struct RenderedBlock {
+    pub(crate) index: usize,
+    pub(crate) snippet: String,
+    pub(crate) breadcrumb: String,
+}
+
+pub(crate) struct RenderedMarkdown {
+    pub(crate) html: String,
+    pub(crate) blocks: Vec<RenderedBlock>,
+}
+
+#[derive(Clone, Copy)]
+enum AnchorTarget {
+    Element(&'static str),
+    PreWrapper,
+    TableWrapper,
+}
+
+struct PlannedBlock {
+    node_id: Option<usize>,
+    target: AnchorTarget,
+    snippet: String,
+    breadcrumb: String,
+}
+
+#[derive(Clone, Copy)]
+struct RenderAnchor {
+    index: usize,
+    target: AnchorTarget,
+}
+
+struct RenderContext {
+    anchors: HashMap<usize, RenderAnchor>,
+}
+
+/// Parses markdown once, plans its outermost commentable blocks, and renders
+/// stamps from that same plan.
+pub(crate) fn render_markdown(markdown: &str) -> RenderedMarkdown {
+    let mut planned = Vec::new();
+    let mut footnotes = Vec::new();
+    let mut heading_stack: Vec<(u8, String)> = Vec::new();
+
+    let (frontmatter, body) = if let Some((frontmatter, body)) = split_frontmatter(markdown) {
+        planned.push(PlannedBlock {
+            node_id: None,
+            target: AnchorTarget::PreWrapper,
+            snippet: truncate_snippet(frontmatter.trim()),
+            breadcrumb: String::new(),
+        });
+        (Some(frontmatter), body)
+    } else {
+        (None, markdown)
+    };
+
+    let options = render_options();
+    let arena = Arena::new();
+    let root = parse_document(&arena, body, &options);
+
+    for node in root.children() {
+        let node_key = node_id(node);
+        match &node.data.borrow().value {
+            NodeValue::Heading(heading) => {
+                // h6 is deliberately neither commentable nor part of the
+                // breadcrumb hierarchy.
+                if heading.level > 5 {
+                    continue;
+                }
+                let text = plain_text(node);
+                heading_stack.retain(|(level, _)| *level < heading.level);
+                heading_stack.push((heading.level, text.clone()));
+                planned.push(PlannedBlock {
+                    node_id: Some(node_key),
+                    target: AnchorTarget::Element(match heading.level {
+                        1 => "<h1",
+                        2 => "<h2",
+                        3 => "<h3",
+                        4 => "<h4",
+                        5 => "<h5",
+                        _ => unreachable!(),
+                    }),
+                    snippet: truncate_snippet(&text),
+                    breadcrumb: breadcrumb(&heading_stack),
+                });
+            }
+            NodeValue::Paragraph => planned.push(planned_node(
+                node,
+                node_key,
+                AnchorTarget::Element("<p"),
+                &heading_stack,
+            )),
+            NodeValue::BlockQuote => planned.push(planned_node(
+                node,
+                node_key,
+                AnchorTarget::Element("<blockquote"),
+                &heading_stack,
+            )),
+            NodeValue::Table(_) => planned.push(planned_node(
+                node,
+                node_key,
+                AnchorTarget::TableWrapper,
+                &heading_stack,
+            )),
+            NodeValue::CodeBlock(code_block) => planned.push(PlannedBlock {
+                node_id: Some(node_key),
+                target: AnchorTarget::PreWrapper,
+                snippet: truncate_snippet(code_block.literal.trim_end()),
+                breadcrumb: breadcrumb(&heading_stack),
+            }),
+            NodeValue::List(_) => {
+                // Only direct children of a root list are outermost anchors.
+                for item in node.children() {
+                    if matches!(
+                        item.data.borrow().value,
+                        NodeValue::Item(_) | NodeValue::TaskItem(_)
+                    ) {
+                        planned.push(planned_node(
+                            item,
+                            node_id(item),
+                            AnchorTarget::Element("<li"),
+                            &heading_stack,
+                        ));
+                    }
+                }
+            }
+            NodeValue::FootnoteDefinition(_) => {
+                // Comrak renders referenced definitions as trailing list items.
+                // Keep them after every ordinary body block.
+                footnotes.push(planned_node(
+                    node,
+                    node_key,
+                    AnchorTarget::Element("<li"),
+                    &heading_stack,
+                ));
+            }
+            // Thematic breaks and raw HTML blocks are not commentable.
+            _ => {}
+        }
+    }
+    planned.extend(footnotes);
+
+    let mut anchors = HashMap::new();
+    let blocks = planned
+        .iter()
+        .enumerate()
+        .map(|(offset, block)| {
+            let index = offset + 1;
+            if let Some(node_id) = block.node_id {
+                anchors.insert(
+                    node_id,
+                    RenderAnchor {
+                        index,
+                        target: block.target,
+                    },
+                );
+            }
+            RenderedBlock {
+                index,
+                snippet: block.snippet.clone(),
+                breadcrumb: block.breadcrumb.clone(),
+            }
+        })
+        .collect();
+
+    let mut body_html = String::new();
+    format_document_with_formatter(
+        root,
+        &options,
+        &mut body_html,
+        &Plugins::default(),
+        stamped_formatter,
+        RenderContext { anchors },
+    )
+    .expect("writing rendered markdown to a String cannot fail");
+    inject_element_stamps(&mut body_html, &planned);
+
+    let mut html = frontmatter
+        .map(|yaml| render_frontmatter_block(yaml, 1))
+        .unwrap_or_default();
+    html.push_str(&body_html);
+    RenderedMarkdown { html, blocks }
+}
+
+fn planned_node<'a>(
+    node: &'a AstNode<'a>,
+    node_id: usize,
+    target: AnchorTarget,
+    heading_stack: &[(u8, String)],
+) -> PlannedBlock {
+    PlannedBlock {
+        node_id: Some(node_id),
+        target,
+        snippet: truncate_snippet(&plain_text(node)),
+        breadcrumb: breadcrumb(heading_stack),
+    }
+}
+
+fn node_id(node: &AstNode<'_>) -> usize {
+    node as *const AstNode<'_> as usize
+}
+
+fn stamped_formatter<'a>(
+    context: &mut Context<RenderContext>,
+    node: &'a AstNode<'a>,
+    entering: bool,
+) -> Result<ChildRendering, fmt::Error> {
+    let anchor = context.user.anchors.get(&node_id(node)).copied();
+
+    if entering && let Some(anchor) = anchor {
+        match anchor.target {
+            AnchorTarget::PreWrapper => {
+                write!(
+                    context,
+                    "<div class=\"pre-wrap\" data-anchor-idx=\"{}\">",
+                    anchor.index
+                )?;
+            }
+            AnchorTarget::TableWrapper => {
+                write!(
+                    context,
+                    "<div class=\"table-wrap\" data-anchor-idx=\"{}\">",
+                    anchor.index
+                )?;
+            }
+            AnchorTarget::Element(_) => {}
+        }
+    }
+
+    let children = format_node_default(context, node, entering)?;
+
+    if entering
+        && let Some(RenderAnchor {
+            index,
+            target: AnchorTarget::Element(_),
+        }) = anchor
+    {
+        write!(context, "{ANCHOR_MARKER_PREFIX}{index}-->")?;
+    }
+
+    if !entering
+        && matches!(
+            anchor.map(|anchor| anchor.target),
+            Some(AnchorTarget::PreWrapper | AnchorTarget::TableWrapper)
+        )
+    {
+        context.write_str("</div>\n")?;
+    }
+
+    Ok(children)
+}
+
+fn inject_element_stamps(html: &mut String, planned: &[PlannedBlock]) {
+    for (offset, block) in planned.iter().enumerate() {
+        let AnchorTarget::Element(tag) = block.target else {
+            continue;
+        };
+        let index = offset + 1;
+        let marker = format!("{ANCHOR_MARKER_PREFIX}{index}-->");
+        let marker_start = html
+            .find(&marker)
+            .expect("planned anchor marker should be rendered");
+        let marker_end = marker_start + marker.len();
+        let tag_start = html[..marker_start]
+            .rfind(tag)
+            .expect("planned anchor element should be rendered");
+        html.replace_range(marker_start..marker_end, "");
+        html.insert_str(
+            tag_start + tag.len(),
+            &format!(" data-anchor-idx=\"{index}\""),
+        );
+    }
+}
+
+fn render_frontmatter_block(yaml: &str, index: usize) -> String {
     format!(
-        "<details class=\"front-matter\"><summary>Front Matter</summary><pre><code class=\"language-yaml\">{}</code></pre></details>\n",
+        "<details class=\"front-matter\"><summary>Front Matter</summary><div class=\"pre-wrap\" data-anchor-idx=\"{index}\"><pre><code class=\"language-yaml\">{}</code></pre></div></details>\n",
         escape_html(yaml)
     )
 }
@@ -57,6 +334,51 @@ fn escape_html(input: &str) -> String {
         }
     }
     out
+}
+
+fn breadcrumb(heading_stack: &[(u8, String)]) -> String {
+    heading_stack
+        .iter()
+        .map(|(_, text)| text.as_str())
+        .collect::<Vec<_>>()
+        .join(" › ")
+}
+
+fn plain_text<'a>(node: &'a AstNode<'a>) -> String {
+    let mut out = String::new();
+    collect_plain_text(node, &mut out);
+    out.trim().to_string()
+}
+
+fn collect_plain_text<'a>(node: &'a AstNode<'a>, out: &mut String) {
+    match &node.data.borrow().value {
+        NodeValue::Text(text) => out.push_str(text),
+        NodeValue::Code(code) => out.push_str(&code.literal),
+        NodeValue::SoftBreak | NodeValue::LineBreak => out.push(' '),
+        _ => {
+            for child in node.children() {
+                // Separate nested blocks (paragraphs, nested list items) with
+                // a space so they don't run together in the snippet.
+                if child.data.borrow().value.block() && !out.is_empty() && !out.ends_with(' ') {
+                    out.push(' ');
+                }
+                collect_plain_text(child, out);
+            }
+        }
+    }
+}
+
+fn truncate_snippet(text: &str) -> String {
+    let mut snippet = text.to_string();
+    if snippet.len() <= SNIPPET_MAX_BYTES {
+        return snippet;
+    }
+    let mut boundary = SNIPPET_MAX_BYTES;
+    while !snippet.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    snippet.truncate(boundary);
+    snippet
 }
 
 #[cfg(test)]
@@ -87,11 +409,11 @@ mod tests {
         assert_contains_all(
             &html,
             &[
-                "<h1>One</h1>",
-                "<h2>Two</h2>",
-                "<h3>Three</h3>",
-                "<h4>Four</h4>",
-                "<h5>Five</h5>",
+                "<h1 data-anchor-idx=\"1\">One</h1>",
+                "<h2 data-anchor-idx=\"2\">Two</h2>",
+                "<h3 data-anchor-idx=\"3\">Three</h3>",
+                "<h4 data-anchor-idx=\"4\">Four</h4>",
+                "<h5 data-anchor-idx=\"5\">Five</h5>",
             ],
         );
     }
@@ -118,15 +440,15 @@ fn main() {}
             &html,
             &[
                 "<ul>",
-                "<li>unordered</li>",
+                "<li data-anchor-idx=\"1\">unordered</li>",
                 "<ol>",
-                "<li>ordered</li>",
-                "<blockquote>",
+                "<li data-anchor-idx=\"3\">ordered</li>",
+                "<blockquote data-anchor-idx=\"5\">",
                 "<p>quoted</p>",
                 "<pre><code class=\"language-rust\">fn main() {}",
             ],
         );
-        assert!(!html.contains("<div"));
+        assert_eq!(html.matches("<div class=\"pre-wrap\"").count(), 1);
     }
 
     #[test]
@@ -179,7 +501,7 @@ A---B
 
         assert_eq!(
             html,
-            "<pre><code class=\"language-mermaid\">graph TD\nA---B\n</code></pre>\n"
+            "<div class=\"pre-wrap\" data-anchor-idx=\"1\">\n<pre><code class=\"language-mermaid\">graph TD\nA---B\n</code></pre>\n</div>\n"
         );
     }
 
@@ -194,8 +516,8 @@ A---B
                 "<summary>Front Matter</summary>",
                 "<pre><code class=\"language-yaml\">",
                 "title: Demo\nauthor: Chris\n",
-                "</code></pre></details>",
-                "<h1>Hello</h1>",
+                "</code></pre></div></details>",
+                "<h1 data-anchor-idx=\"2\">Hello</h1>",
             ],
         );
     }
@@ -232,8 +554,8 @@ A---B
             &html,
             &[
                 "<details class=\"front-matter\">",
-                "<h1>Heading</h1>",
-                "<p>para</p>",
+                "<h1 data-anchor-idx=\"2\">Heading</h1>",
+                "<p data-anchor-idx=\"3\">para</p>",
             ],
         );
     }
@@ -247,7 +569,7 @@ A---B
             &[
                 "<details class=\"front-matter\">",
                 "<pre><code class=\"language-yaml\"></code></pre>",
-                "<h1>Title</h1>",
+                "<h1 data-anchor-idx=\"2\">Title</h1>",
             ],
         );
     }
@@ -257,5 +579,114 @@ A---B
         let markdown = "# Title\n\n- [x] item\n\n| a | b |\n| - | - |\n| c | d |\n";
 
         assert_eq!(render(markdown), render(markdown));
+    }
+
+    fn stamped_indices(html: &str) -> Vec<usize> {
+        html.split("data-anchor-idx=\"")
+            .skip(1)
+            .map(|suffix| {
+                suffix
+                    .split_once('"')
+                    .expect("anchor stamp should have a closing quote")
+                    .0
+                    .parse()
+                    .expect("anchor stamp should be numeric")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn rendered_stamps_and_block_indices_share_one_outermost_plan() {
+        let markdown = r#"---
+title: Demo
+---
+# Heading
+###### Not commentable
+
+Paragraph.
+
+> Quote
+>
+> - nested item
+> - nested item with code:
+>
+>   ```text
+>   nested
+>   ```
+
+- top item
+  - nested item
+- [x] task item
+
+| a | b |
+| - | - |
+| c | d |
+
+```rust
+fn main() {}
+```
+
+Reference.[^note]
+
+Later.
+
+[^note]: Footnote detail.
+"#;
+
+        let rendered = render_markdown(markdown);
+        let expected: Vec<usize> = (1..=rendered.blocks.len()).collect();
+
+        assert_eq!(
+            rendered
+                .blocks
+                .iter()
+                .map(|block| block.snippet.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "title: Demo",
+                "Heading",
+                "Paragraph.",
+                "Quote nested item nested item with code:",
+                "top item nested item",
+                "task item",
+                "a b c d",
+                "fn main() {}",
+                "Reference.",
+                "Later.",
+                "Footnote detail.",
+            ]
+        );
+        assert_eq!(stamped_indices(&rendered.html), expected);
+        assert!(rendered.html.contains(
+            "<div class=\"pre-wrap\" data-anchor-idx=\"1\"><pre><code class=\"language-yaml\">"
+        ));
+        assert!(
+            rendered
+                .html
+                .contains("<h1 data-anchor-idx=\"2\">Heading</h1>")
+        );
+        assert!(rendered.html.contains("<blockquote data-anchor-idx=\"4\">"));
+        assert!(rendered.html.contains("<li data-anchor-idx=\"5\">top item"));
+        assert!(
+            rendered
+                .html
+                .contains("<div class=\"table-wrap\" data-anchor-idx=\"7\">")
+        );
+        assert!(
+            rendered
+                .html
+                .contains("<li data-anchor-idx=\"11\" id=\"fn-note\">")
+        );
+        assert_eq!(
+            rendered.html.matches("<div class=\"table-wrap\"").count(),
+            1
+        );
+        assert_eq!(rendered.html.matches("class=\"pre-wrap\"").count(), 2);
+        assert!(rendered.html.contains("<section class=\"footnotes"));
+        assert!(!rendered.html.contains("###### Not commentable"));
+        assert_eq!(
+            rendered.html.matches("data-anchor-idx=").count(),
+            rendered.blocks.len()
+        );
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -352,6 +352,16 @@ mod tests {
     }
 
     #[test]
+    fn bundled_template_does_not_resegment_markdown_anchors() {
+        let page = render_page("<p data-anchor-idx=\"1\">Doc</p>", "{}", "[]");
+
+        assert!(!page.contains("COMMENTABLE_SELECTOR"));
+        assert!(!page.contains("assignAnchorIndices"));
+        assert!(!page.contains("setAttribute('data-anchor-idx'"));
+        assert!(page.contains("<p data-anchor-idx=\"1\">Doc</p>"));
+    }
+
+    #[test]
     fn bundled_template_has_accessible_collapsible_file_sidebar() {
         let page = render_page("<p>Doc</p>", "{}", "[]");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -177,6 +177,64 @@ fn cli_emits_single_session_started_event_after_listening() {
 }
 
 #[test]
+fn cli_serves_server_stamped_markdown_anchors_matching_blocks_api() {
+    let temp_dir = tempdir().expect("tempdir should be created");
+    let home_dir = temp_dir.path().join("home");
+    fs::create_dir(&home_dir).expect("home dir should be created");
+    let markdown_path = temp_dir.path().join("review.md");
+    fs::write(
+        &markdown_path,
+        "---\ntitle: Review\n---\n# Plan\n\nBody.\n\n| a |\n| - |\n| b |\n\n```rust\nfn main() {}\n```\n\nReference.[^note]\n\n[^note]: Detail.\n",
+    )
+    .expect("markdown file should be written");
+
+    let mut session = spawn_dynamic_session(temp_dir.path(), &home_dir, &markdown_path);
+    let started = receive_startup(&session, "anchor HTML");
+    let base_url = startup_base_url(&started);
+    assert_startup_contract(&session, &started, &base_url);
+
+    let root_response = http_request_url(&base_url, "GET", None);
+    assert!(root_response.starts_with("HTTP/1.1 200"), "{root_response}");
+    let html = doc_content(response_body(&root_response));
+    assert!(html.contains("<h1 data-anchor-idx=\"2\">Plan</h1>"));
+    assert!(html.contains("class=\"table-wrap\" data-anchor-idx=\"4\""));
+    assert!(html.contains("class=\"pre-wrap\" data-anchor-idx=\"5\""));
+
+    let blocks_url = started["payload"]["endpoints"]["blocksTemplate"]
+        .as_str()
+        .expect("blocksTemplate endpoint should be a string")
+        .replace("{fileId}", "f-1");
+    let blocks_response = http_request_url(&blocks_url, "GET", None);
+    assert!(
+        blocks_response.starts_with("HTTP/1.1 200"),
+        "{blocks_response}"
+    );
+    let blocks = response_json(&blocks_response);
+    let block_indices = blocks["blocks"]
+        .as_array()
+        .expect("blocks array")
+        .iter()
+        .map(|block| block["index"].as_u64().expect("numeric block index"))
+        .collect::<Vec<_>>();
+    assert_eq!(stamped_indices(html), block_indices);
+    assert_eq!(block_indices, (1..=7).collect::<Vec<_>>());
+
+    let done_url = started["payload"]["endpoints"]["done"]
+        .as_str()
+        .expect("done endpoint should be a string");
+    let done_response = http_request_url(done_url, "POST", None);
+    assert!(done_response.starts_with("HTTP/1.1 200"), "{done_response}");
+    let output = wait_with_timeout(
+        session
+            .child
+            .take()
+            .expect("session child should be present"),
+        Duration::from_secs(2),
+    );
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
 fn concurrent_sessions_use_distinct_reported_endpoints_without_state_leakage() {
     let temp_dir = tempdir().expect("tempdir should be created");
     let home_dir = temp_dir.path().join("home");
@@ -696,12 +754,39 @@ fn http_request_head_bytes(port: u16, path: &str) -> String {
     String::from_utf8_lossy(&response[..head_end]).into_owned()
 }
 
-fn response_json(response: &str) -> Value {
-    let body = response
+fn response_body(response: &str) -> &str {
+    response
         .split_once("\r\n\r\n")
         .expect("HTTP response should contain a body")
-        .1;
-    serde_json::from_str(body).expect("HTTP response body should be JSON")
+        .1
+}
+
+fn response_json(response: &str) -> Value {
+    serde_json::from_str(response_body(response)).expect("HTTP response body should be JSON")
+}
+
+fn doc_content(body: &str) -> &str {
+    let open = "<section id=\"doc-content\">";
+    let start = body.find(open).expect("doc-content open") + open.len();
+    let end = body[start..]
+        .find("</section>")
+        .map(|offset| start + offset)
+        .expect("doc-content close");
+    &body[start..end]
+}
+
+fn stamped_indices(html: &str) -> Vec<u64> {
+    html.split("data-anchor-idx=\"")
+        .skip(1)
+        .map(|suffix| {
+            suffix
+                .split_once('"')
+                .expect("anchor stamp should have a closing quote")
+                .0
+                .parse()
+                .expect("anchor stamp should be numeric")
+        })
+        .collect()
 }
 
 #[derive(Clone, Copy)]

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -46,7 +46,10 @@ async fn get_root_renders_template_and_shutdown_completes() {
             .to_ascii_lowercase()
             .contains("cache-control: no-store")
     );
-    assert!(doc_content(response_body(&response)).contains("<h1>Review Plan</h1>"));
+    assert!(
+        doc_content(response_body(&response))
+            .contains("<h1 data-anchor-idx=\"1\">Review Plan</h1>")
+    );
 
     shutdown_tx.send(()).expect("send shutdown signal");
     timeout(Duration::from_secs(1), shutdown_rx.changed())
@@ -122,7 +125,9 @@ async fn get_root_seeds_current_state_for_reload() {
 
     assert!(initial_state.contains("\"u-one\""));
     assert!(initial_state.contains("\"u-two\""));
-    assert!(doc_content(response_body(&response)).contains("<h1>State Seed</h1>"));
+    assert!(
+        doc_content(response_body(&response)).contains("<h1 data-anchor-idx=\"1\">State Seed</h1>")
+    );
 
     shutdown_tx.send(()).expect("send shutdown signal");
     timeout(Duration::from_secs(1), server)
@@ -2646,12 +2651,11 @@ async fn post_api_source_swaps_source_reanchors_threads_and_broadcasts() {
 
     let payload = response_json(&response);
     assert_eq!(payload["markdown"], "# New Title\n\nNew body.");
-    assert!(
-        payload["renderedHtml"]
-            .as_str()
-            .expect("renderedHtml string")
-            .contains("<h1>New Title</h1>")
-    );
+    let rendered_html = payload["renderedHtml"]
+        .as_str()
+        .expect("renderedHtml string");
+    assert!(rendered_html.contains("<h1 data-anchor-idx=\"1\">New Title</h1>"));
+    assert_eq!(stamped_indices(rendered_html), vec![1, 2]);
     assert_eq!(payload["sourceVersion"], 1);
     assert_eq!(payload["orphanedThreadIds"], json!(["u-lost"]));
     let anchors = payload["threadAnchors"]
@@ -2673,7 +2677,8 @@ async fn post_api_source_swaps_source_reanchors_threads_and_broadcasts() {
     // SSE broadcast carries the same payload.
     let event = read_until(&mut sse, "\n\n").await;
     assert!(event.contains("event: source.updated"), "event: {event}");
-    assert!(event.contains("<h1>New Title</h1>"));
+    let event_payload = sse_data_json(&event);
+    assert_eq!(event_payload["renderedHtml"], payload["renderedHtml"]);
 
     // Stdout event emitted for observing agents.
     let stdout_line = stdout_string(&stdout);
@@ -2684,7 +2689,12 @@ async fn post_api_source_swaps_source_reanchors_threads_and_broadcasts() {
 
     // Root page renders the new source; state reflects new anchors + version.
     let response = get_root(addr).await;
-    assert!(doc_content(response_body(&response)).contains("<h1>New Title</h1>"));
+    assert_eq!(
+        stamped_indices(doc_content(response_body(&response))),
+        vec![1, 2]
+    );
+    let blocks = response_json(&get_path(addr, "/api/files/f-1/blocks").await);
+    assert_eq!(block_indices(&blocks), vec![1, 2]);
     let state = response_json(&get_path(addr, "/api/state").await);
     assert_eq!(state["sourceVersion"], 1);
     let threads = state["threads"].as_array().expect("threads array");
@@ -2779,7 +2789,7 @@ async fn post_api_source_enforces_strict_thread_coverage() {
     let state = response_json(&get_path(addr, "/api/state").await);
     assert_eq!(state["sourceVersion"], 0);
     let response = get_root(addr).await;
-    assert!(doc_content(response_body(&response)).contains("<h1>Doc</h1>"));
+    assert!(doc_content(response_body(&response)).contains("<h1 data-anchor-idx=\"1\">Doc</h1>"));
 
     shutdown_tx.send(()).expect("send shutdown signal");
     timeout(Duration::from_secs(1), server)
@@ -2917,6 +2927,98 @@ async fn post_api_source_requires_anchors_for_agent_threads() {
 }
 
 #[tokio::test]
+async fn markdown_stamp_delivery_matches_blocks_api_for_every_supported_block_kind() {
+    let addr = free_loopback_addr();
+    let initial_markdown = all_commentable_blocks_markdown("Initial heading");
+    let app_state = AppState::for_process().with_markdown_source(initial_markdown.as_str());
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let server = tokio::spawn(serve(addr, app_state, async move {
+        let _ = shutdown_rx.await;
+    }));
+
+    wait_for_server(addr).await;
+
+    let initial_blocks = response_json(&get_path(addr, "/api/files/f-1/blocks").await);
+    let expected_indices: Vec<u64> = (1..=16).collect();
+    assert_eq!(block_indices(&initial_blocks), expected_indices);
+
+    let root = get_root(addr).await;
+    let root_body = response_body(&root);
+    let initial_html = doc_content(root_body);
+    assert_eq!(
+        stamped_indices(initial_html),
+        block_indices(&initial_blocks)
+    );
+    assert!(initial_html.contains("class=\"front-matter\""));
+    assert!(initial_html.contains("class=\"table-wrap\" data-anchor-idx=\"11\""));
+    assert!(initial_html.contains("class=\"language-mermaid\""));
+    assert!(initial_html.contains("class=\"footnotes\""));
+    let rendered_files = rendered_files_json(root_body);
+    assert_eq!(
+        stamped_indices(
+            rendered_files[0]["html"]
+                .as_str()
+                .expect("rendered file HTML")
+        ),
+        block_indices(&initial_blocks)
+    );
+
+    let mut sse = open_get_path(addr, "/api/events").await;
+    let headers = read_until(&mut sse, "\r\n\r\n").await;
+    assert_sse_headers(&headers);
+
+    let updated_markdown = all_commentable_blocks_markdown("Updated heading");
+    let update = post_json_path(
+        addr,
+        "/api/source",
+        &json!({ "markdown": updated_markdown, "threadAnchors": [] }).to_string(),
+    )
+    .await;
+    assert!(update.starts_with("HTTP/1.1 200"), "response: {update}");
+    let update_payload = response_json(&update);
+    let updated_html = update_payload["renderedHtml"]
+        .as_str()
+        .expect("source update renderedHtml");
+
+    let event = read_until(&mut sse, "\n\n").await;
+    assert!(event.contains("event: source.updated"), "event: {event}");
+    assert_eq!(
+        sse_data_json(&event)["renderedHtml"],
+        update_payload["renderedHtml"]
+    );
+
+    let updated_blocks = response_json(&get_path(addr, "/api/files/f-1/blocks").await);
+    assert_eq!(
+        stamped_indices(updated_html),
+        block_indices(&updated_blocks)
+    );
+    assert_eq!(block_indices(&updated_blocks), expected_indices);
+
+    let updated_root = get_root(addr).await;
+    let updated_root_body = response_body(&updated_root);
+    assert_eq!(
+        stamped_indices(doc_content(updated_root_body)),
+        block_indices(&updated_blocks)
+    );
+    let updated_rendered_files = rendered_files_json(updated_root_body);
+    assert_eq!(
+        stamped_indices(
+            updated_rendered_files[0]["html"]
+                .as_str()
+                .expect("updated rendered file HTML")
+        ),
+        block_indices(&updated_blocks)
+    );
+
+    shutdown_tx.send(()).expect("send shutdown signal");
+    timeout(Duration::from_secs(1), server)
+        .await
+        .expect("server exits within timeout")
+        .expect("server task should not panic")
+        .expect("server shutdown should succeed");
+}
+
+#[tokio::test]
 async fn get_api_file_blocks_returns_segmentation_with_source_version() {
     let addr = free_loopback_addr();
     let app_state = AppState::for_process()
@@ -2941,6 +3043,22 @@ async fn get_api_file_blocks_returns_segmentation_with_source_version() {
             { "index": 2, "snippet": "We will stage the rollout.", "breadcrumb": "Rollout plan" },
             { "index": 3, "snippet": "by region", "breadcrumb": "Rollout plan" }
         ])
+    );
+
+    let root = get_root(addr).await;
+    let root_body = response_body(&root);
+    assert_eq!(
+        stamped_indices(doc_content(root_body)),
+        block_indices(&body)
+    );
+    let rendered_files = rendered_files_json(root_body);
+    assert_eq!(
+        stamped_indices(
+            rendered_files[0]["html"]
+                .as_str()
+                .expect("rendered file HTML")
+        ),
+        block_indices(&body)
     );
 
     shutdown_tx.send(()).expect("send shutdown signal");
@@ -3420,7 +3538,7 @@ async fn get_root_seeds_rendered_files_and_file_metadata_for_multi_file_sessions
 
     // First file is injected into #doc-content; every file is seeded into
     // the rendered-files map for client-side switching.
-    assert!(doc_content(body).contains("<h1>Alpha</h1>"));
+    assert!(doc_content(body).contains("<h1 data-anchor-idx=\"1\">Alpha</h1>"));
     assert!(body.contains("window.__DISCUSS_RENDERED_FILES__ = "));
     assert!(body.contains(r#"{"id":"f-1","html":"#));
     assert!(body.contains(r#"{"id":"f-2","html":"#));
@@ -3566,7 +3684,7 @@ async fn post_api_source_scopes_coverage_and_payload_to_the_updated_file() {
         payload["renderedHtml"]
             .as_str()
             .unwrap()
-            .contains("<h1>Alpha v2</h1>")
+            .contains("<h1 data-anchor-idx=\"1\">Alpha v2</h1>")
     );
     assert_eq!(payload["threadAnchors"], json!([]));
 
@@ -4246,6 +4364,54 @@ fn thread_with_kind(id: &str, anchor_start: usize, kind: ThreadKind) -> Thread {
     }
 }
 
+fn all_commentable_blocks_markdown(heading: &str) -> String {
+    r#"---
+title: Demo
+---
+# __HEADING__
+## Level two
+### Level three
+#### Level four
+##### Level five
+###### Not commentable
+
+Paragraph.
+
+> Quote
+>
+> - nested item
+> - nested code:
+>
+>   ```text
+>   nested
+>   ```
+
+- top item
+  - nested item
+- [x] task item
+
+| a | b |
+| - | - |
+| c | d |
+
+```rust
+fn main() {}
+```
+
+```mermaid
+graph TD
+A---B
+```
+
+Reference.[^note]
+
+Later.
+
+[^note]: Footnote detail.
+"#
+    .replacen("__HEADING__", heading, 1)
+}
+
 fn response_body(response: &str) -> &str {
     response
         .split_once("\r\n\r\n")
@@ -4255,6 +4421,47 @@ fn response_body(response: &str) -> &str {
 
 fn response_json(response: &str) -> Value {
     serde_json::from_str(response_body(response)).expect("response body should be JSON")
+}
+
+fn stamped_indices(html: &str) -> Vec<u64> {
+    html.split("data-anchor-idx=\"")
+        .skip(1)
+        .map(|suffix| {
+            suffix
+                .split_once('"')
+                .expect("anchor stamp should have a closing quote")
+                .0
+                .parse()
+                .expect("anchor stamp should be numeric")
+        })
+        .collect()
+}
+
+fn block_indices(response: &Value) -> Vec<u64> {
+    response["blocks"]
+        .as_array()
+        .expect("blocks array")
+        .iter()
+        .map(|block| block["index"].as_u64().expect("numeric block index"))
+        .collect()
+}
+
+fn sse_data_json(event: &str) -> Value {
+    let data = event
+        .lines()
+        .find_map(|line| line.strip_prefix("data: "))
+        .expect("SSE event data");
+    serde_json::from_str(data).expect("SSE data should be JSON")
+}
+
+fn rendered_files_json(body: &str) -> Value {
+    let open = "window.__DISCUSS_RENDERED_FILES__ = ";
+    let start = body.find(open).expect("rendered-files script") + open.len();
+    let end = body[start..]
+        .find(";\n</script>")
+        .map(|offset| start + offset)
+        .expect("rendered-files assignment terminator");
+    serde_json::from_str(&body[start..end]).expect("rendered-files assignment should be JSON")
 }
 
 fn doc_content(body: &str) -> &str {


### PR DESCRIPTION
## Summary

- make the Rust Markdown render plan the single source of truth for commentable-block indices and rendered `data-anchor-idx` attributes
- emit server-side `.pre-wrap` and `.table-wrap` anchor carriers while preserving frontmatter, outermost list/blockquote, and footnote ordering
- remove browser-side `COMMENTABLE_SELECTOR` / `assignAnchorIndices()` segmentation and anchor-writing fallbacks
- verify parity across initial page seeds, pre-rendered file HTML, source-update REST responses, SSE payloads, reloads, and the blocks API

## Testing

- `cargo fmt --all -- --check`
- `RUSTFLAGS='-D warnings' cargo clippy --all-targets`
- `RUSTFLAGS='-D warnings' cargo build --all-targets`
- `RUSTFLAGS='-D warnings' cargo test`
- `git diff --check`

Closes #43
