### PR TITLE
feat: add row-level table anchors

### DIFF
--- a/discuss.html
+++ b/discuss.html
@@ -4349,8 +4349,8 @@
       return stack;
     }
 
-    // Rows live inside the horizontally scrolling .table-scroll. Keep their
-    // markers on the stationary wrapper and align them vertically to the row.
+    // Keep row markers out of the table's layout and on its outer wrapper,
+    // aligned vertically to the row.
     const wrapper = anchor.closest('.table-wrap');
     if (!wrapper) return null;
     const idx = anchor.getAttribute('data-anchor-idx');

--- a/discuss.html
+++ b/discuss.html
@@ -1055,6 +1055,12 @@
     outline: 1px dashed var(--accent-dashed);
     outline-offset: 2px;
   }
+  /* A row is the precise hover target inside a table. Do not also paint the
+     retained whole-table anchor when the pointer is over an anchored row. */
+  #doc-content .table-wrap[data-anchor-idx]:has(tr[data-anchor-idx]:hover) {
+    background: transparent;
+    outline: none;
+  }
   #doc-content [data-anchor-idx].focused {
     background: var(--accent-soft);
     outline: 1px solid var(--accent);
@@ -3560,8 +3566,18 @@
       }
       node = node.parentElement;
     }
-    // De-duplicate consecutive entries
-    return path.filter((v, i) => i === 0 || v !== path[i - 1]).join(' › ');
+    // De-duplicate consecutive entries, then identify precise table rows.
+    const deduped = path.filter((v, i) => i === 0 || v !== path[i - 1]);
+    if (anchorEl && anchorEl.tagName === 'TR') {
+      const section = anchorEl.parentElement;
+      if (section && section.tagName === 'THEAD') {
+        deduped.push('Table header');
+      } else if (section) {
+        const row = Array.from(section.children).filter(el => el.tagName === 'TR').indexOf(anchorEl) + 1;
+        deduped.push(`Table row ${row}`);
+      }
+    }
+    return deduped.join(' › ');
   }
 
   // ---------- Prepopulated threads ----------
@@ -4322,6 +4338,35 @@
       });
   }
 
+  function markerStackForAnchor(anchor) {
+    if (anchor.tagName !== 'TR') {
+      let stack = anchor.querySelector(':scope > .thread-marker-stack');
+      if (!stack) {
+        stack = document.createElement('div');
+        stack.className = 'thread-marker-stack';
+        anchor.appendChild(stack);
+      }
+      return stack;
+    }
+
+    // Rows live inside the horizontally scrolling .table-scroll. Keep their
+    // markers on the stationary wrapper and align them vertically to the row.
+    const wrapper = anchor.closest('.table-wrap');
+    if (!wrapper) return null;
+    const idx = anchor.getAttribute('data-anchor-idx');
+    let stack = wrapper.querySelector(`:scope > .thread-marker-stack[data-row-anchor-idx="${idx}"]`);
+    if (!stack) {
+      stack = document.createElement('div');
+      stack.className = 'thread-marker-stack';
+      stack.setAttribute('data-row-anchor-idx', idx);
+      wrapper.appendChild(stack);
+    }
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const rowRect = anchor.getBoundingClientRect();
+    stack.style.top = (rowRect.top - wrapperRect.top + 1) + 'px';
+    return stack;
+  }
+
   function renderMarkers() {
     document.querySelectorAll('.thread-marker-stack, .thread-marker').forEach(el => el.remove());
     document.querySelectorAll('.image-pin-marker').forEach(el => el.remove());
@@ -4394,7 +4439,12 @@
           stack.appendChild(marker);
         }
       });
-      if (stack) anchor.appendChild(stack);
+      if (stack) {
+        const host = markerStackForAnchor(anchor);
+        if (host) {
+          while (stack.firstChild) host.appendChild(stack.firstChild);
+        }
+      }
     });
 
     // Render new-thread draft markers (teal, dashed, "…"). These live
@@ -4457,13 +4507,8 @@
         marker.style.top = top + 'px';
         anchor.appendChild(marker);
       } else {
-        let stack = anchor.querySelector('.thread-marker-stack');
-        if (!stack) {
-          stack = document.createElement('div');
-          stack.className = 'thread-marker-stack';
-          anchor.appendChild(stack);
-        }
-        stack.appendChild(marker);
+        const stack = markerStackForAnchor(anchor);
+        if (stack) stack.appendChild(marker);
       }
     });
 

--- a/src/blocks.rs
+++ b/src/blocks.rs
@@ -91,22 +91,28 @@ mod tests {
     }
 
     #[test]
-    fn tables_are_single_blocks_and_thematic_breaks_are_skipped() {
+    fn tables_keep_a_whole_table_block_and_add_row_blocks() {
         let blocks = snippets("before\n\n| a | b |\n| - | - |\n| c | d |\n\n---\n\nafter\n");
 
-        assert_eq!(blocks, vec!["before", "a b c d", "after"]);
+        assert_eq!(blocks, vec!["before", "a b c d", "a b", "c d", "after"]);
     }
 
     #[test]
-    fn tables_get_heading_breadcrumb_and_document_order_index() {
-        let blocks = markdown_blocks("# Plan\n\nintro\n\n| a |\n| - |\n| b |\n\nafter\n");
+    fn table_rows_get_identifying_breadcrumbs_and_document_order_indices() {
+        let blocks = markdown_blocks("# Plan\n\nintro\n\n| a |\n| - |\n| b |\n| c |\n\nafter\n");
 
         assert_eq!(
             blocks.iter().map(|b| b.index).collect::<Vec<_>>(),
-            vec![1, 2, 3, 4]
+            vec![1, 2, 3, 4, 5, 6, 7]
         );
-        assert_eq!(blocks[2].snippet, "a b");
+        assert_eq!(blocks[2].snippet, "a b c");
         assert_eq!(blocks[2].breadcrumb, "Plan");
+        assert_eq!(blocks[3].snippet, "a");
+        assert_eq!(blocks[3].breadcrumb, "Plan › Table header");
+        assert_eq!(blocks[4].snippet, "b");
+        assert_eq!(blocks[4].breadcrumb, "Plan › Table row 1");
+        assert_eq!(blocks[5].snippet, "c");
+        assert_eq!(blocks[5].breadcrumb, "Plan › Table row 2");
     }
 
     #[test]

--- a/src/render.rs
+++ b/src/render.rs
@@ -140,12 +140,32 @@ pub(crate) fn render_markdown(markdown: &str) -> RenderedMarkdown {
                 AnchorTarget::Element("<blockquote"),
                 &heading_stack,
             )),
-            NodeValue::Table(_) => planned.push(planned_node(
-                node,
-                node_key,
-                AnchorTarget::TableWrapper,
-                &heading_stack,
-            )),
+            NodeValue::Table(_) => {
+                // Keep the table-level anchor first so existing table threads
+                // continue to resolve, then add one precise anchor per row.
+                planned.push(planned_node(
+                    node,
+                    node_key,
+                    AnchorTarget::TableWrapper,
+                    &heading_stack,
+                ));
+                for (row_offset, row) in node.children().enumerate() {
+                    let is_header = matches!(row.data.borrow().value, NodeValue::TableRow(true));
+                    let row_label = if is_header {
+                        "Table header".to_string()
+                    } else {
+                        format!("Table row {row_offset}")
+                    };
+                    let mut row_breadcrumb = heading_stack.clone();
+                    row_breadcrumb.push((6, row_label));
+                    planned.push(planned_node(
+                        row,
+                        node_id(row),
+                        AnchorTarget::Element("<tr"),
+                        &row_breadcrumb,
+                    ));
+                }
+            }
             NodeValue::CodeBlock(code_block) => planned.push(PlannedBlock {
                 node_id: Some(node_key),
                 target: AnchorTarget::PreWrapper,
@@ -650,6 +670,8 @@ Later.
                 "top item nested item",
                 "task item",
                 "a b c d",
+                "a b",
+                "c d",
                 "fn main() {}",
                 "Reference.",
                 "Later.",
@@ -672,10 +694,12 @@ Later.
                 .html
                 .contains("<div class=\"table-wrap\" data-anchor-idx=\"7\">")
         );
+        assert!(rendered.html.contains("<tr data-anchor-idx=\"8\">"));
+        assert!(rendered.html.contains("<tr data-anchor-idx=\"9\">"));
         assert!(
             rendered
                 .html
-                .contains("<li data-anchor-idx=\"11\" id=\"fn-note\">")
+                .contains("<li data-anchor-idx=\"13\" id=\"fn-note\">")
         );
         assert_eq!(
             rendered.html.matches("<div class=\"table-wrap\"").count(),

--- a/tests/browser/table-row-anchors-smoke.mjs
+++ b/tests/browser/table-row-anchors-smoke.mjs
@@ -1,0 +1,174 @@
+// Dependency-free Chrome DevTools Protocol smoke test for Markdown table rows.
+// Usage: DISCUSS_URL=http://127.0.0.1:7792 CDP_URL=http://127.0.0.1:9227 node tests/browser/table-row-anchors-smoke.mjs
+
+const discussUrl = process.env.DISCUSS_URL || 'http://127.0.0.1:7792';
+const cdpUrl = process.env.CDP_URL || 'http://127.0.0.1:9227';
+
+const targets = await (await fetch(`${cdpUrl}/json`)).json();
+const target = targets.find(item => item.type === 'page');
+if (!target) throw new Error('Chrome exposes no page target');
+
+const socket = new WebSocket(target.webSocketDebuggerUrl);
+let nextId = 0;
+const pending = new Map();
+const runtimeErrors = [];
+socket.onmessage = event => {
+  const message = JSON.parse(event.data);
+  if (message.id && pending.has(message.id)) {
+    const handlers = pending.get(message.id);
+    pending.delete(message.id);
+    if (message.error) handlers.reject(new Error(JSON.stringify(message.error)));
+    else handlers.resolve(message.result);
+  }
+  if (message.method === 'Runtime.exceptionThrown') {
+    runtimeErrors.push(message.params.exceptionDetails.exception?.description || message.params.exceptionDetails.text);
+  }
+};
+await new Promise((resolve, reject) => {
+  socket.onopen = resolve;
+  socket.onerror = reject;
+});
+
+function send(method, params = {}) {
+  const id = ++nextId;
+  socket.send(JSON.stringify({ id, method, params }));
+  return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+}
+
+async function evaluate(expression) {
+  const response = await send('Runtime.evaluate', {
+    expression,
+    awaitPromise: true,
+    returnByValue: true,
+  });
+  if (response.exceptionDetails) {
+    throw new Error(response.exceptionDetails.exception?.description || response.exceptionDetails.text);
+  }
+  return response.result.value;
+}
+
+async function waitFor(expression, description, attempts = 60) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const value = await evaluate(expression);
+    if (value) return value;
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${description}`);
+}
+
+async function click(point) {
+  await send('Input.dispatchMouseEvent', {
+    type: 'mousePressed', x: point.x, y: point.y, button: 'left', clickCount: 1,
+  });
+  await send('Input.dispatchMouseEvent', {
+    type: 'mouseReleased', x: point.x, y: point.y, button: 'left', clickCount: 1,
+  });
+}
+
+async function center(selector) {
+  return evaluate(`(() => {
+    const rect = document.querySelector(${JSON.stringify(selector)}).getBoundingClientRect();
+    return { x: rect.x + rect.width / 2, y: rect.y + rect.height / 2 };
+  })()`);
+}
+
+await send('Runtime.enable');
+await send('Page.enable');
+await send('Emulation.setDeviceMetricsOverride', {
+  width: 900, height: 700, deviceScaleFactor: 1, mobile: false,
+});
+await send('Page.navigate', { url: discussUrl });
+await waitFor(`document.querySelectorAll('.table-wrap tr[data-anchor-idx]').length === 3`, 'stamped table rows');
+
+const blocks = await (await fetch(`${discussUrl}/api/files/f-1/blocks`)).json();
+const tableBlocks = blocks.blocks.filter(block => block.index >= 2 && block.index <= 5);
+if (
+  tableBlocks.length !== 4
+  || tableBlocks[0].breadcrumb !== 'Plan'
+  || tableBlocks[1].snippet !== 'Item Estimate Notes'
+  || tableBlocks[1].breadcrumb !== 'Plan › Table header'
+  || tableBlocks[2].snippet !== 'Alpha 1 day short'
+  || tableBlocks[2].breadcrumb !== 'Plan › Table row 1'
+  || !tableBlocks[3].snippet.startsWith('Beta 20 days wide value')
+  || tableBlocks[3].breadcrumb !== 'Plan › Table row 2'
+) {
+  throw new Error(`Unexpected table block metadata: ${JSON.stringify(tableBlocks)}`);
+}
+
+const anchors = await evaluate(`Array.from(document.querySelectorAll('.table-wrap [data-anchor-idx]')).map(el => ({
+  tag: el.tagName,
+  index: Number(el.dataset.anchorIdx),
+  text: el.textContent.trim().replace(/\\s+/g, ' '),
+}))`);
+if (JSON.stringify(anchors.map(anchor => [anchor.tag, anchor.index])) !== JSON.stringify([
+  ['TR', 3], ['TR', 4], ['TR', 5],
+])) {
+  throw new Error(`Rows were not stamped in DOM order: ${JSON.stringify(anchors)}`);
+}
+
+await click(await center('.table-wrap tbody tr:nth-child(2) td:nth-child(2)'));
+const editorRef = await waitFor(`document.querySelector('.new-thread-editor .anchor-ref')?.textContent`, 'row editor');
+if (!editorRef.startsWith('#5 · Beta 20 days wide value')) {
+  throw new Error(`Click did not target the precise row: ${editorRef}`);
+}
+const focusState = await evaluate(`({
+  row: document.querySelector('.table-wrap tbody tr:nth-child(2)').classList.contains('focused'),
+  table: document.querySelector('.table-wrap').classList.contains('focused'),
+})`);
+if (!focusState.row || focusState.table) {
+  throw new Error(`Wrong table focus hierarchy: ${JSON.stringify(focusState)}`);
+}
+
+await evaluate(`(() => {
+  const textarea = document.querySelector('.new-thread-editor textarea');
+  textarea.value = 'Row estimate is too high';
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  return true;
+})()`);
+await click(await center('.new-thread-editor .save'));
+await waitFor(`document.querySelector('.thread[data-thread-id="u-1"]')`, 'saved row thread');
+
+let state;
+for (let attempt = 0; attempt < 50; attempt++) {
+  state = await (await fetch(`${discussUrl}/api/state`)).json();
+  if (state.threads?.[0]?.id === 'u-1') break;
+  await new Promise(resolve => setTimeout(resolve, 100));
+}
+const saved = state.threads?.[0];
+if (!saved || saved.anchorStart !== 5 || saved.anchorEnd !== 5 || !saved.snippet.startsWith('Beta 20 days wide value')) {
+  throw new Error(`Server did not persist the row anchor: ${JSON.stringify(saved)}`);
+}
+
+const markerPosition = await waitFor(`(() => {
+  const row = document.querySelector('.table-wrap tbody tr:nth-child(2)');
+  const wrapper = document.querySelector('.table-wrap');
+  const stack = wrapper.querySelector(':scope > .thread-marker-stack[data-row-anchor-idx="5"]');
+  if (!stack) return null;
+  const rowRect = row.getBoundingClientRect();
+  const markerRect = stack.getBoundingClientRect();
+  return { rowY: rowRect.y, markerY: markerRect.y, markerX: markerRect.x, wrapperRight: wrapper.getBoundingClientRect().right };
+})()`, 'row gutter marker');
+if (Math.abs(markerPosition.rowY - markerPosition.markerY) > 3) {
+  throw new Error(`Marker is not vertically aligned to its row: ${JSON.stringify(markerPosition)}`);
+}
+
+const markerHost = await evaluate(`(() => {
+  const marker = document.querySelector('.table-wrap > .thread-marker-stack[data-row-anchor-idx="5"]');
+  return marker ? {
+    directChildOfWrapper: marker.parentElement.classList.contains('table-wrap'),
+    outsideRow: !document.querySelector('.table-wrap tbody tr:nth-child(2)').contains(marker),
+  } : null;
+})()`);
+if (!markerHost?.directChildOfWrapper || !markerHost.outsideRow) {
+  throw new Error(`Row marker was placed inside table content: ${JSON.stringify(markerHost)}`);
+}
+if (runtimeErrors.length) throw new Error(`Browser runtime errors: ${runtimeErrors.join('; ')}`);
+
+console.log(JSON.stringify({
+  ok: true,
+  rowAnchors: anchors.map(anchor => anchor.index),
+  editorRef,
+  savedAnchor: saved.anchorStart,
+  markerAnchoredToTableGutter: true,
+}));
+socket.close();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -198,7 +198,9 @@ fn cli_serves_server_stamped_markdown_anchors_matching_blocks_api() {
     let html = doc_content(response_body(&root_response));
     assert!(html.contains("<h1 data-anchor-idx=\"2\">Plan</h1>"));
     assert!(html.contains("class=\"table-wrap\" data-anchor-idx=\"4\""));
-    assert!(html.contains("class=\"pre-wrap\" data-anchor-idx=\"5\""));
+    assert!(html.contains("<tr data-anchor-idx=\"5\">"));
+    assert!(html.contains("<tr data-anchor-idx=\"6\">"));
+    assert!(html.contains("class=\"pre-wrap\" data-anchor-idx=\"7\""));
 
     let blocks_url = started["payload"]["endpoints"]["blocksTemplate"]
         .as_str()
@@ -217,7 +219,7 @@ fn cli_serves_server_stamped_markdown_anchors_matching_blocks_api() {
         .map(|block| block["index"].as_u64().expect("numeric block index"))
         .collect::<Vec<_>>();
     assert_eq!(stamped_indices(html), block_indices);
-    assert_eq!(block_indices, (1..=7).collect::<Vec<_>>());
+    assert_eq!(block_indices, (1..=9).collect::<Vec<_>>());
 
     let done_url = started["payload"]["endpoints"]["done"]
         .as_str()

--- a/tests/server.rs
+++ b/tests/server.rs
@@ -2939,7 +2939,7 @@ async fn markdown_stamp_delivery_matches_blocks_api_for_every_supported_block_ki
     wait_for_server(addr).await;
 
     let initial_blocks = response_json(&get_path(addr, "/api/files/f-1/blocks").await);
-    let expected_indices: Vec<u64> = (1..=16).collect();
+    let expected_indices: Vec<u64> = (1..=18).collect();
     assert_eq!(block_indices(&initial_blocks), expected_indices);
 
     let root = get_root(addr).await;
@@ -3070,7 +3070,7 @@ async fn get_api_file_blocks_returns_segmentation_with_source_version() {
 }
 
 #[tokio::test]
-async fn get_api_file_blocks_counts_tables_as_single_blocks() {
+async fn get_api_file_blocks_includes_whole_table_and_row_anchors() {
     let addr = free_loopback_addr();
     let app_state = AppState::for_process()
         .with_markdown_source("# Plan\n\nintro\n\n| a | b |\n| - | - |\n| c | d |\n\nafter\n");
@@ -3084,14 +3084,15 @@ async fn get_api_file_blocks_counts_tables_as_single_blocks() {
     let response = get_path(addr, "/api/files/f-1/blocks").await;
     assert!(response.starts_with("HTTP/1.1 200"), "response: {response}");
     let body = response_json(&response);
-    // The table is one block, matching the browser's .table-wrap anchor.
     assert_eq!(
         body["blocks"],
         json!([
             { "index": 1, "snippet": "Plan", "breadcrumb": "Plan" },
             { "index": 2, "snippet": "intro", "breadcrumb": "Plan" },
             { "index": 3, "snippet": "a b c d", "breadcrumb": "Plan" },
-            { "index": 4, "snippet": "after", "breadcrumb": "Plan" }
+            { "index": 4, "snippet": "a b", "breadcrumb": "Plan › Table header" },
+            { "index": 5, "snippet": "c d", "breadcrumb": "Plan › Table row 1" },
+            { "index": 6, "snippet": "after", "breadcrumb": "Plan" }
         ])
     );
 


### PR DESCRIPTION
Closes #45.

## Summary
- preserve the existing whole-table anchor and add server-stamped row anchors
- provide row-specific snippets and breadcrumbs
- keep row markers on the table wrapper gutter
- add a dependency-free CDP browser smoke test for row selection, persistence, and marker placement
- update rendering, blocks API, CLI, and server coverage

## Testing
- `cargo fmt --check`
- `cargo test`
- `git diff --check`
- `DISCUSS_URL=http://127.0.0.1:7792 CDP_URL=http://127.0.0.1:9227 node tests/browser/table-row-anchors-smoke.mjs`