### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-08-30
+
+### Added
+
+- **Row-level table comments** — markdown tables retain their whole-table anchor for compatibility and now add a server-stamped anchor for each header/body row, so clicking a cell or selecting text targets that specific row. Row threads use row-limited snippets and identifying breadcrumbs, while their markers stay aligned in the table wrapper gutter instead of entering the table layout. A dependency-free Chrome DevTools Protocol smoke test covers row selection, persistence, and marker placement. Closes [#45](https://github.com/codesoda/discuss-cli/issues/45).
+
+- **What’s new version history** — when the header detects an available update, its version badge now opens a popover containing the GitHub release notes for every stable version newer than the running binary, plus the existing copyable `discuss update -y` command. Release-history lookup is non-fatal and uses the same process-lifetime cache as the latest-version check.
+
+### Changed
+
+- **Server-stamped markdown anchors** — commentable block indices are now planned and stamped into rendered HTML by the same server-side AST pass that serves `GET /api/files/{fileId}/blocks`. The browser consumes those stamps instead of independently re-segmenting the DOM, eliminating drift between browser and agent anchors and providing the single source of truth used by row-level table anchors. Closes [#43](https://github.com/codesoda/discuss-cli/issues/43).
+
 ## [0.9.1] - 2026-08-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "discuss"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discuss"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.88"
 description = "A Rust CLI for live bidirectional markdown review sessions."

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Same outcome as the curl path. This path builds the binary from source with `car
 
 ### Staying current
 
-Run `discuss update --check` to check for a newer release. Run `discuss update -y` to install it without a prompt. The browser header also shows a version badge. When a newer release exists, the badge becomes a button that copies `discuss update -y`.
+Run `discuss update --check` to check for a newer release. Run `discuss update -y` to install it without a prompt. The browser header also shows a version badge. When a newer release exists, open the badge to see the release notes for every version since the one currently running and copy `discuss update -y`.
 
 ## Quick Start
 
@@ -218,7 +218,7 @@ Agents should use the exact URLs in `session.started.payload.endpoints` rather t
 |--------|------|---------|
 | `GET` | `/api/state` | Current snapshot: threads, replies, takes, drafts, files, verdictConfig, sourceVersion |
 | `GET` | `/api/events` | SSE event stream (browser UI) |
-| `GET` | `/api/version` | Cached, non-fatal update check against the latest GitHub release |
+| `GET` | `/api/version` | Cached, non-fatal update check with release notes for every newer stable GitHub release |
 | `GET` | `/api/files/{fileId}/raw` | Raw bytes for an image file |
 | `GET` | `/files/{fileId}` | Served HTML prototype with inspector/base injection |
 | `GET` | `/files/{fileId}/assets/{*path}` | Sandboxed relative prototype asset |

--- a/discuss.html
+++ b/discuss.html
@@ -203,7 +203,9 @@
     gap: 16px;
   }
   header h1 { margin: 0; font-size: 16px; font-weight: 600; }
-  header .header-version { color: var(--muted); font-size: 12px; white-space: nowrap; }
+  header .header-version { position: relative; color: var(--muted); font-size: 12px; white-space: nowrap; }
+  header .header-version .version-update > summary { list-style: none; }
+  header .header-version .version-update > summary::-webkit-details-marker { display: none; }
   header .header-version .update-copy {
     font: inherit;
     font-size: 12px;
@@ -216,6 +218,40 @@
   }
   header .header-version .update-copy:hover { background: var(--accent-hover); }
   header .header-version .update-copy.copied { background: var(--accent); color: var(--accent-ink); border-color: var(--accent); }
+  header .header-version .version-notes {
+    position: absolute;
+    top: calc(100% + 10px);
+    left: 0;
+    width: min(520px, calc(100vw - 32px));
+    max-height: min(560px, calc(100vh - var(--header-h) - 24px));
+    overflow-y: auto;
+    padding: 14px;
+    white-space: normal;
+    color: var(--ink);
+    background: var(--card);
+    border: 1px solid var(--line-strong);
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+    z-index: 120;
+  }
+  header .header-version .version-notes h2 { margin: 0 0 10px; font-size: 15px; }
+  header .header-version .version-notes h3 { margin: 14px 0 4px; font-size: 13px; }
+  header .header-version .version-notes pre {
+    margin: 0;
+    font: inherit;
+    font-size: 12px;
+    line-height: 1.45;
+    white-space: pre-wrap;
+  }
+  header .header-version .version-notes .copy-update-command {
+    margin-top: 14px;
+    padding: 6px 10px;
+    border: 1px solid var(--accent);
+    border-radius: 4px;
+    color: var(--accent);
+    background: transparent;
+    cursor: pointer;
+  }
   header .meta { color: var(--muted); font-size: 13px; }
   header .thread-summary { position: relative; }
   header .thread-summary-popover {
@@ -2303,9 +2339,9 @@
 
   // ---------- Version badge ----------
   // Shows the running discuss version next to the header title. A background
-  // check against /api/version (which resolves the latest GitHub release
-  // server-side) upgrades the badge into a one-click copy of the update
-  // command when a newer version exists. Failures leave the badge hidden.
+  // check against /api/version (which resolves GitHub releases server-side)
+  // upgrades the badge into a What's new popover with every stable release
+  // since the running version. Failures leave the badge hidden.
   const UPDATE_COMMAND = 'discuss update -y';
 
   function initVersionBadge() {
@@ -2317,26 +2353,45 @@
         if (!info || !info.current) return;
         el.hidden = false;
         if (info.updateAvailable && info.latest) {
-          const button = document.createElement('button');
-          button.type = 'button';
-          button.className = 'update-copy';
-          button.textContent = `v${info.current} — update available (v${info.latest})`;
-          button.title = `Click to copy \`${UPDATE_COMMAND}\` for a terminal or agent`;
-          button.addEventListener('click', () => {
+          const details = document.createElement('details');
+          details.className = 'version-update';
+          const summary = document.createElement('summary');
+          summary.className = 'update-copy';
+          summary.textContent = `v${info.current} — update available (v${info.latest})`;
+          summary.title = 'Show changes available in newer versions';
+          const popover = document.createElement('div');
+          popover.className = 'version-notes';
+          const heading = document.createElement('h2');
+          heading.textContent = `What’s new since v${info.current}`;
+          popover.appendChild(heading);
+          (info.releases || []).forEach(release => {
+            const version = document.createElement('h3');
+            version.textContent = `v${release.version}`;
+            const notes = document.createElement('pre');
+            notes.textContent = release.notes || 'No release notes provided.';
+            popover.append(version, notes);
+          });
+          if (!info.releases || info.releases.length === 0) {
+            const unavailable = document.createElement('pre');
+            unavailable.textContent = 'Release notes are temporarily unavailable.';
+            popover.appendChild(unavailable);
+          }
+          const copyButton = document.createElement('button');
+          copyButton.type = 'button';
+          copyButton.className = 'copy-update-command';
+          copyButton.textContent = `Copy \`${UPDATE_COMMAND}\``;
+          copyButton.addEventListener('click', () => {
             copyTextToClipboard(UPDATE_COMMAND).then(() => {
-              const label = button.textContent;
-              button.classList.add('copied');
-              button.textContent = `Copied \`${UPDATE_COMMAND}\` ✓`;
-              setTimeout(() => {
-                button.classList.remove('copied');
-                button.textContent = label;
-              }, 2000);
+              copyButton.textContent = 'Copied ✓';
+              setTimeout(() => { copyButton.textContent = `Copy \`${UPDATE_COMMAND}\``; }, 2000);
             }).catch(() => {
-              button.textContent = `Copy failed — run \`${UPDATE_COMMAND}\``;
+              copyButton.textContent = `Copy failed — run \`${UPDATE_COMMAND}\``;
             });
           });
+          popover.appendChild(copyButton);
+          details.append(summary, popover);
           el.textContent = '';
-          el.appendChild(button);
+          el.appendChild(details);
         } else {
           el.textContent = `v${info.current}`;
           el.title = 'discuss is up to date';

--- a/src/server/pages.rs
+++ b/src/server/pages.rs
@@ -167,7 +167,7 @@ pub(super) async fn get_api_version() -> Response {
     let status = tokio::task::spawn_blocking(update::version_status)
         .await
         .unwrap_or_else(|_| VersionStatus::current_only());
-    if status.latest.is_some() {
+    if status.latest.is_some() && (!status.update_available || !status.releases.is_empty()) {
         let _ = VERSION_STATUS_CACHE.set(status.clone());
     }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -578,7 +578,7 @@ mod tests {
     }
 
     #[test]
-    fn bundled_template_shows_version_badge_with_update_copy() {
+    fn bundled_template_shows_version_history_and_update_copy() {
         let page = render_page("<p>Doc</p>", r#"{"threads":[]}"#, "[]");
 
         assert!(page.contains("<h1>Discuss</h1>"));
@@ -586,6 +586,8 @@ mod tests {
         assert!(page.contains("id=\"header-version\""));
         assert!(page.contains("fetch('/api/version'"));
         assert!(page.contains("const UPDATE_COMMAND = 'discuss update -y';"));
+        assert!(page.contains("What’s new since v${info.current}"));
+        assert!(page.contains("(info.releases || []).forEach"));
         assert!(page.contains("copyTextToClipboard(UPDATE_COMMAND)"));
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use flate2::read::GzDecoder;
 use reqwest::blocking::Client;
-use reqwest::header::{HeaderMap, LOCATION};
+use reqwest::header::{HeaderMap, LOCATION, USER_AGENT};
 use reqwest::redirect::Policy;
 use semver::Version;
 use serde::Serialize;
@@ -44,10 +44,18 @@ pub fn check() -> Result<String> {
 /// release lookup fails (offline, rate limited) so the UI can degrade quietly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct ReleaseNotes {
+    pub version: String,
+    pub notes: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct VersionStatus {
     pub current: String,
     pub latest: Option<String>,
     pub update_available: bool,
+    pub releases: Vec<ReleaseNotes>,
 }
 
 impl VersionStatus {
@@ -59,7 +67,13 @@ impl VersionStatus {
 /// Non-fatal version lookup backing `GET /api/version`; never errors so a
 /// failed release check cannot break the review page.
 pub fn version_status() -> VersionStatus {
-    build_version_status(env!("CARGO_PKG_VERSION"), latest_release().ok())
+    let current = env!("CARGO_PKG_VERSION");
+    let latest = latest_release().ok();
+    let mut status = build_version_status(current, latest);
+    if status.update_available {
+        status.releases = release_notes_since(current).unwrap_or_default();
+    }
+    status
 }
 
 fn build_version_status(current: &str, latest: Option<LatestRelease>) -> VersionStatus {
@@ -74,7 +88,86 @@ fn build_version_status(current: &str, latest: Option<LatestRelease>) -> Version
         current: current.to_string(),
         latest: latest.map(|release| release.version.to_string()),
         update_available,
+        releases: Vec::new(),
     }
+}
+
+#[derive(serde::Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    body: Option<String>,
+    draft: bool,
+    prerelease: bool,
+}
+
+fn release_notes_since(current: &str) -> Result<Vec<ReleaseNotes>> {
+    let current = parse_version(current, "the current package version")?;
+    let url = github_releases_api_url()?;
+    let client = download_client()?;
+    let response = client
+        .get(&url)
+        .header(
+            USER_AGENT,
+            concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")),
+        )
+        .send()
+        .map_err(|source| {
+            update_check_error(format!(
+                "could not reach {url} within {} seconds: {source}",
+                UPDATE_TIMEOUT.as_secs()
+            ))
+        })?;
+    if !response.status().is_success() {
+        return Err(update_check_error(format!(
+            "GitHub returned HTTP {} for {url}",
+            response.status().as_u16()
+        )));
+    }
+    let body = response.text().map_err(|source| {
+        update_check_error(format!(
+            "could not read release history from {url}: {source}"
+        ))
+    })?;
+    let releases: Vec<GithubRelease> = serde_json::from_str(&body).map_err(|source| {
+        update_check_error(format!(
+            "could not parse release history from {url}: {source}"
+        ))
+    })?;
+
+    Ok(release_notes_after(&current, releases))
+}
+
+fn github_releases_api_url() -> Result<String> {
+    let repository = env!("CARGO_PKG_REPOSITORY");
+    let path = repository
+        .strip_prefix("https://github.com/")
+        .ok_or_else(|| {
+            update_check_error(format!("unsupported GitHub repository URL {repository}"))
+        })?
+        .trim_end_matches('/');
+    Ok(format!(
+        "https://api.github.com/repos/{path}/releases?per_page=100"
+    ))
+}
+
+fn release_notes_after(current: &Version, releases: Vec<GithubRelease>) -> Vec<ReleaseNotes> {
+    releases
+        .into_iter()
+        .filter(|release| !release.draft && !release.prerelease)
+        .filter_map(|release| {
+            let version = Version::parse(
+                release
+                    .tag_name
+                    .strip_prefix('v')
+                    .unwrap_or(&release.tag_name),
+            )
+            .ok()?;
+            (version > *current).then(|| ReleaseNotes {
+                version: version.to_string(),
+                notes: release.body.unwrap_or_default(),
+            })
+        })
+        .collect()
 }
 
 pub fn install(yes: bool) -> Result<String> {
@@ -569,6 +662,47 @@ mod tests {
         let unknown = build_version_status("0.1.0", None);
         assert_eq!(unknown.latest, None);
         assert!(!unknown.update_available);
+    }
+
+    #[test]
+    fn release_notes_include_every_stable_release_after_current() {
+        let release = |tag: &str, notes: &str, draft: bool, prerelease: bool| GithubRelease {
+            tag_name: tag.to_string(),
+            body: Some(notes.to_string()),
+            draft,
+            prerelease,
+        };
+        let current = Version::parse("0.8.0").expect("valid version");
+
+        let notes = release_notes_after(
+            &current,
+            vec![
+                release("v0.10.0", "rows", false, false),
+                release("v0.9.1", "demo", false, false),
+                release("v0.9.0", "agents", false, false),
+                release("v0.8.0", "current", false, false),
+                release("v0.11.0-beta.1", "preview", false, true),
+                release("v0.12.0", "draft", true, false),
+            ],
+        );
+
+        assert_eq!(
+            notes,
+            vec![
+                ReleaseNotes {
+                    version: "0.10.0".to_string(),
+                    notes: "rows".to_string(),
+                },
+                ReleaseNotes {
+                    version: "0.9.1".to_string(),
+                    notes: "demo".to_string(),
+                },
+                ReleaseNotes {
+                    version: "0.9.0".to_string(),
+                    notes: "agents".to_string(),
+                },
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- show release notes for every stable version newer than the running binary
- add the update-history popover while retaining the copyable update command
- bump the crate to v0.10.0
- document #43, #45, and version history in the changelog

## Verification
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo build --all-targets`
- `cargo test`
- release-note extraction smoke check
- `git diff --check`