### PR TITLE
Make commenting the default HTML prototype mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Commenting is the default HTML prototype mode** — selecting an element no longer drops the review back into pass-through mode, so consecutive comments need no re-arming. The header toggle is now **Interact** (still `I`): press it when you want clicks to drive the prototype — walk a flow, flip a toggle — and press it again to return to commenting. A banner shows while Interact mode is on; commenting mode is unmarked because it is the default.
+
 ## [0.10.0] - 2026-08-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Engineers share most non-code work as markdown: PRDs, design docs, RFCs, post-mo
 - **Multi-file sessions** — `discuss a.md b.md c.md` reviews several files in one session with a file sidebar.
 - **Image review** — `discuss mockup.png` renders the image. Drop numbered pins to anchor threads to coordinates.
 - **First-class diff review** — `discuss diff` opens the staged git diff with per-hunk syntax highlighting and line-anchored threads. It combines with the file list: `discuss plan.md diff HEAD~1..HEAD`.
-- **HTML prototype review** — `discuss prototype.html` renders the local prototype and its relative assets in a sandboxed iframe. Inspect mode anchors threads to DOM elements with resilient selector fallbacks.
+- **HTML prototype review** — `discuss prototype.html` renders the local prototype and its relative assets in a sandboxed iframe. Clicking an element anchors a thread to it with resilient selector fallbacks; Interact mode hands clicks back to the prototype.
 - **Rich rendering** — Prism highlights tagged code fences (e.g. ` ```rust `, ` ```diff-typescript `). ` ```mermaid ` fences render as diagrams. YAML frontmatter renders as a collapsed, threadable block. See [Prism's supported languages](https://prismjs.com/#supported-languages).
 - **Takes vs replies** — the agent posts *takes* (its view), humans post *replies*. The UI renders them distinctly so you can tell who said what.
 - **Agent pre-annotations** — an agent that edited the doc can open `kind: "agent"` threads before you start reading. Each one marks a change and explains it.
@@ -123,7 +123,7 @@ Two limits apply in this first version. `POST /api/source` is not supported for 
 discuss ./prototype.html
 ```
 
-The prototype runs in a same-origin iframe sandboxed with `allow-scripts allow-same-origin`. Click **Inspect** (or press `I`), hover to outline an element, then click it to open a thread. Saved threads render as numbered in-frame markers. Opening a thread scrolls the prototype back to its element. Selectors use stable ids and data attributes when available. Structural fallbacks come next, then text similarity as a final reattachment fallback.
+The prototype runs in a same-origin iframe sandboxed with `allow-scripts allow-same-origin`. Commenting is the default: hover to outline an element, then click it to open a thread. To drive the prototype itself — walk a flow, press its buttons — click **Interact** (or press `I`); press it again to return to commenting. Saved threads render as numbered in-frame markers. Opening a thread scrolls the prototype back to its element. Selectors use stable ids and data attributes when available. Structural fallbacks come next, then text similarity as a final reattachment fallback.
 
 Relative CSS, JavaScript, images, and fonts resolve from the HTML file's directory. Asset paths are canonicalized and cannot escape that directory. Root-absolute URLs such as `/img/logo.png` are not rewritten; use relative URLs. Served copies have CSP meta tags removed so the injected inspector can run. Closed shadow-root internals cannot be selected in v1; anchor the host instead. Live file watching/reload is not included, and `POST /api/source` is not supported for HTML files.
 

--- a/discuss.html
+++ b/discuss.html
@@ -323,7 +323,7 @@
     font-size: 12px;
     font-weight: 600;
   }
-  body.inspecting #inspect-banner { display: block; }
+  body.html-file:not(.inspecting):not(.review-complete) #inspect-banner { display: block; }
   header .header-icon-link {
     display: inline-flex;
     align-items: center;
@@ -1672,7 +1672,7 @@
     <div class="thread-summary-popover" id="thread-summary-popover" role="region" aria-label="Threads" hidden></div>
   </span>
   <button class="toggle" id="show-all" title="Pin every thread open at once">Show all</button>
-  <button class="toggle" id="inspect-toggle" title="Inspect prototype elements (I)" aria-pressed="false">Inspect</button>
+  <button class="toggle" id="inspect-toggle" title="Interact with the prototype (I)" aria-pressed="false">Interact</button>
   <span class="theme-menu" id="theme-menu">
     <button class="theme-toggle" id="theme-toggle" type="button" aria-label="Color theme" aria-haspopup="menu" aria-expanded="false" title="Color theme">
       <svg class="theme-icon theme-icon-system" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="13" rx="2"></rect><path d="M8 21h8"></path><path d="M12 17v4"></path></svg>
@@ -1705,7 +1705,7 @@
 <div class="done-banner" id="done-banner" role="status" aria-live="polite">
   You can close this tab.
 </div>
-<div id="inspect-banner" role="status">Inspecting — click an element to comment</div>
+<div id="inspect-banner" role="status">Interact mode — clicks drive the prototype · press I to comment</div>
 
 <div class="verdict-modal" id="verdict-modal" hidden>
   <div class="verdict-dialog" role="dialog" aria-modal="true" aria-labelledby="verdict-prompt">
@@ -3323,8 +3323,11 @@
     document.body.classList.toggle('inspecting', inspectOn);
     const button = document.getElementById('inspect-toggle');
     if (button) {
-      button.classList.toggle('on', inspectOn);
-      button.setAttribute('aria-pressed', inspectOn ? 'true' : 'false');
+      // The button shows the special mode: pressed means the prototype is
+      // interactive and clicks pass through instead of commenting.
+      const interacting = isHtmlFile() && !inspectOn;
+      button.classList.toggle('on', interacting);
+      button.setAttribute('aria-pressed', interacting ? 'true' : 'false');
     }
     postToPrototype('discuss:set-inspect', { on: inspectOn });
   }
@@ -3341,8 +3344,9 @@
     document.body.classList.toggle('html-file', isHtmlFile());
     if (!isHtmlFile()) setInspectMode(false);
     else {
-      // HTML review starts ready to select: requiring a separate toggle made
-      // the prototype's own borders look like inactive selection affordances.
+      // HTML review defaults to commenting and stays armed across saves;
+      // the Interact toggle is the special mode that hands clicks to the
+      // prototype.
       setInspectMode(true);
       syncHtmlAnchors();
     }
@@ -3391,7 +3395,6 @@
       postToPrototype('discuss:set-inspect', { on: inspectOn });
       syncHtmlAnchors();
     } else if (message.type === 'discuss:element-selected') {
-      setInspectMode(false);
       openHtmlThreadEditor(message);
     } else if (message.type === 'discuss:marker-clicked') {
       const thread = document.querySelector(`.thread[data-thread-id="${CSS.escape(String(message.threadId))}"]`);

--- a/skills/discuss/SKILL.md
+++ b/skills/discuss/SKILL.md
@@ -70,7 +70,7 @@ Pass `.html` or `.htm` files directly:
 discuss prototype.html
 ```
 
-The browser renders each prototype in a sandboxed iframe and offers **Inspect** mode. HTML `thread.created` events carry `elementAnchor` with `selector`, ordered `fallbacks`, `tag`, optional `textDigest`, and a truncated `outerHtml` snippet. Use `breadcrumb` and `snippet` for readable context; inspect `outerHtml` when the visual element is ambiguous. Agent takes still use `POST /api/threads/{id}/takes`.
+The browser renders each prototype in a sandboxed iframe; clicking an element comments on it by default, and an **Interact** toggle hands clicks to the prototype instead. HTML `thread.created` events carry `elementAnchor` with `selector`, ordered `fallbacks`, `tag`, optional `textDigest`, and a truncated `outerHtml` snippet. Use `breadcrumb` and `snippet` for readable context; inspect `outerHtml` when the visual element is ambiguous. Agent takes still use `POST /api/threads/{id}/takes`.
 
 Prototype-relative assets are served from the HTML file's directory. Root-absolute URLs are not rewritten. `POST /api/source` and live file watching are not supported for HTML files in this version.
 

--- a/tests/browser/html-prototype-smoke.mjs
+++ b/tests/browser/html-prototype-smoke.mjs
@@ -155,6 +155,7 @@ if (!editorSurvivedResolverEcho) {
 }
 await click(await center('.html-thread-editor .cancel'));
 await waitFor(`!document.querySelector('.html-thread-editor')`, 'heading editor close');
+await waitFor(`document.body.classList.contains('inspecting')`, 'commenting mode persists after cancel');
 
 // Scroll through the actual iframe viewport, then select a lower CTA with real pointer input.
 const frameCenter = await center('.prototype-frame');
@@ -163,8 +164,7 @@ await send('Input.dispatchMouseEvent', {
   type: 'mouseWheel', ...frameCenter, deltaX: 0, deltaY: 620,
 });
 await new Promise(resolve => setTimeout(resolve, 250));
-await click(inspectButton);
-await waitFor(`document.body.classList.contains('inspecting')`, 'Inspect mode after iframe scroll');
+await waitFor(`document.body.classList.contains('inspecting')`, 'commenting mode persists after iframe scroll');
 const ctaPoint = await framePoint('[data-test="buy-team"]');
 if (ctaPoint.y < 54 || ctaPoint.y > 760) throw new Error(`CTA did not scroll into view: ${JSON.stringify(ctaPoint)}`);
 await send('Input.dispatchMouseEvent', { type: 'mouseMoved', ...ctaPoint });
@@ -198,6 +198,18 @@ const saved = apiState.threads?.[0];
 if (!saved || saved.elementAnchor?.selector !== '#pricing [data-test="buy-team"]') {
   throw new Error(`Server did not persist the expected anchor: ${JSON.stringify(saved)}`);
 }
+await waitFor(`document.body.classList.contains('inspecting')`, 'commenting mode persists after save');
+
+// The Interact toggle is the special mode: it hands clicks to the prototype
+// and restores its cursor, and a second press returns to commenting.
+await click(inspectButton);
+await waitFor(`!document.body.classList.contains('inspecting')`, 'Interact mode on toggle press');
+await waitFor(
+  `document.querySelector('.prototype-frame').contentDocument.documentElement.style.cursor !== 'crosshair'`,
+  'inspector crosshair cursor released in Interact mode',
+);
+await click(inspectButton);
+await waitFor(`document.body.classList.contains('inspecting')`, 'commenting mode after leaving Interact');
 
 // Close the card, then use the in-frame marker's real hit target to reopen it.
 await click(await center('.element-thread .thread-close'));


### PR DESCRIPTION
## What

On HTML prototype review, commenting is now the default mode and stays on across saves. The header toggle becomes **Interact** (shortcut `I` unchanged): press it to hand clicks to the prototype, press it again to return to commenting.

## Why

Inspect mode armed on load and then disarmed on every element selection, so only the first comment worked. Later clicks reopened existing threads instead of starting new ones, which reads as the review being frozen. Reproduced on a real prototype: comment one saves, then the page appears stuck until you notice the small "Inspecting" pill has vanished and re-click Inspect.

Arming exists for a good reason — while armed, the prototype's own JavaScript never fires, so you cannot walk a flow — but that is the exception, not the default. This inverts the two: commenting is unmarked and always available, and driving the prototype is the explicit mode with a banner.

## Changes

- `discuss.html` — element selection no longer calls `setInspectMode(false)`; the toggle reflects the Interact state via `aria-pressed`; the banner and its label now describe Interact mode.
- `tests/browser/html-prototype-smoke.mjs` — asserts commenting survives cancel, iframe scroll, and save; adds an Interact round-trip covering the released crosshair cursor.
- `README.md`, `skills/discuss/SKILL.md`, `CHANGELOG.md` — copy updated.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets`, `cargo test` (332 tests) all pass with `RUSTFLAGS="-D warnings"`.
- `tests/browser/html-prototype-smoke.mjs` passes end to end against `examples/prototype.html`.
- Driven by hand against a real prototype: two comments back to back with no toolbar trip, Interact mode operates the prototype's own theme toggle, and commenting resumes on leaving it.

## Screenshots

<!-- image: Interact mode — banner visible and the toggle pressed -->

## Notes

Pre-existing and untouched here: the `I` shortcut does not fire while focus is inside the prototype iframe, since the parent document never sees those key events. The toolbar button always works.