### PR TITLE
chore: prepare v0.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-09-04
+
 ### Added
 
 - **Expanded self-contained demo** — one `discuss demo` launch now exposes the existing six-file feature tour, a deterministic synthetic private-first PR review, and a bundled running local-app review through a shared header switcher. The PR scenario uses the production import/state/UI contracts for nested changed files, GitHub-style diffs, imported issue/review/inline discussion, local takes, Viewed progression, editable Finish Review, and exact GFM confirmation; its exclusive demo execution mode generates a local summary and simulates OK locally, making `gh`, agent publication events, and the real publisher unreachable. The mini app serves root-relative CSS/JavaScript, an app API, and SPA routes in-process on its own loopback origin, then uses the production live proxy and inspector for route-scoped element anchors, markers, and canned responses. All five listeners bind before readiness, demo update checks stay offline, history stays disabled, and no LLM, GitHub authentication, external app process, or public network is required. README video/GIF and the deterministic recording pipeline now cover both workflows. Closes [#56](https://github.com/codesoda/discuss-cli/issues/56).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,7 +429,7 @@ dependencies = [
 
 [[package]]
 name = "discuss"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-stream",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discuss"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.88"
 description = "A Rust CLI for live bidirectional markdown review sessions."


### PR DESCRIPTION
## Summary

- bump the crate/package version from `0.11.0` to `0.11.1`
- update the root `discuss` package entry in `Cargo.lock`
- move the merged expanded-demo changelog entry under `0.11.1` dated 2026-09-04

No tag or GitHub Release is created by this PR.

## Verification

- `cargo fmt --check` — passed
- `cargo clippy --all-targets -- -D warnings` — passed
- `cargo build --all-targets` — passed
- `cargo test` — passed (395 tests, 0 failed)
- `./target/debug/discuss --version` — `discuss 0.11.1`
- `git diff --check` — passed
